### PR TITLE
fix(FEC-6841): change getters called 'name' to 'id'

### DIFF
--- a/src/k-provider/ovp/loaders/data-loader-manager.js
+++ b/src/k-provider/ovp/loaders/data-loader-manager.js
@@ -53,7 +53,7 @@ export default class DataLoaderManager {
   add(loader: Function, params: Object): void {
     let execution_loader = new loader(params);
     if (execution_loader.isValid()) {
-      this._loaders.set(loader.name, execution_loader);
+      this._loaders.set(loader.id, execution_loader);
       //Get the start index from the multiReqeust before adding current execution_loader requests
       let startIndex = this._multiRequest.requests.length;
       //Get the requests
@@ -65,7 +65,7 @@ export default class DataLoaderManager {
       //Create range array of current execution_loader requests
       let executionLoaderResponseMap = Array.from(new Array(requests.length), (val, index) => index + startIndex);
       //Add to map
-      DataLoaderManager._loadersResponseMap.set(loader.name, executionLoaderResponseMap);
+      DataLoaderManager._loadersResponseMap.set(loader.id, executionLoaderResponseMap);
     }
   }
 

--- a/src/k-provider/ovp/loaders/media-entry-loader.js
+++ b/src/k-provider/ovp/loaders/media-entry-loader.js
@@ -15,7 +15,7 @@ const config = Configuration.get();
  * @classdesc
  */
 export default class MediaEntryLoader implements ILoader {
-  static get name(): string {
+  static get id(): string {
     return "media";
   }
 

--- a/src/k-provider/ovp/loaders/session-loader.js
+++ b/src/k-provider/ovp/loaders/session-loader.js
@@ -9,7 +9,7 @@ const config = Configuration.get();
  * @classdesc
  */
 export default class SessionLoader implements ILoader {
-  static get name(): string {
+  static get id(): string {
     return "session";
   }
 

--- a/src/k-provider/ovp/loaders/ui-config-loader.js
+++ b/src/k-provider/ovp/loaders/ui-config-loader.js
@@ -7,7 +7,7 @@ import RequestBuilder from '../../request-builder'
 const config = Configuration.get();
 
 export default class UiConfigLoader implements ILoader {
-  static get name(): string {
+  static get id(): string {
     return "uiConf";
   }
 

--- a/src/k-provider/ovp/ovp-provider.js
+++ b/src/k-provider/ovp/ovp-provider.js
@@ -128,23 +128,23 @@ export class OvpProvider {
       plugins: {}
     };
     if (data != null) {
-      if (data.has(SessionLoader.name)) {
-        let sessionLoader = data.get(SessionLoader.name);
+      if (data.has(SessionLoader.id)) {
+        let sessionLoader = data.get(SessionLoader.id);
         if (sessionLoader != null && sessionLoader.response != null) {
           this.ks = sessionLoader.response;
           config.session.ks = this.ks;
         }
       }
-      if (data.has(UiConfigLoader.name)) {
-        let uiConfLoader = data.get(UiConfigLoader.name);
+      if (data.has(UiConfigLoader.id)) {
+        let uiConfLoader = data.get(UiConfigLoader.id);
         let pluginsJson: Object = {};
         if (uiConfLoader != null) {
           pluginsJson = uiConfLoader.response;
         }
         config.plugins = pluginsJson;
       }
-      if (data.has(MediaEntryLoader.name)) {
-        let mediaLoader = data.get(MediaEntryLoader.name);
+      if (data.has(MediaEntryLoader.id)) {
+        let mediaLoader = data.get(MediaEntryLoader.id);
         if (mediaLoader != null && mediaLoader.response != null) {
           let mediaEntry: MediaEntry = ProviderParser.getMediaEntry(this._isAnonymous ? "" : this.ks, this.partnerID, this._uiConfId, mediaLoader.response);
           config.id = mediaEntry.id;


### PR DESCRIPTION
### Description of the Changes

Issue is due to provider code trying to define property called name on an object, which is not supported apparently on Safari on iOS9.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
