### PR TITLE
fix(FEC-7186): support external/universal live entries

### DIFF
--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -149,17 +149,15 @@ export default class ProviderParser {
     if (kalturaSource) {
       let playUrl: string = "";
       let mediaFormat = SUPPORTED_FORMATS.get(kalturaSource.format);
+      let extension: string = "";
+      if (mediaFormat) {
+        extension = mediaFormat.pathExt;
+        mediaSource.mimetype = mediaFormat.mimeType;
+      }
       // in case playbackSource doesn't have flavors we don't need to build the url and we'll use the provided one.
       if (kalturaSource.hasFlavorIds()) {
-        let extension: string = "";
-        if (!mediaFormat) {
-          if (flavorAssets && flavorAssets.length > 0) {
-            extension = flavorAssets[0].fileExt;
-          }
-        }
-        else {
-          extension = mediaFormat.pathExt;
-          mediaSource.mimetype = mediaFormat.mimeType;
+        if (!extension && flavorAssets && flavorAssets.length > 0) {
+          extension = flavorAssets[0].fileExt;
         }
 
         playUrl = PlaySourceUrlBuilder.build({


### PR DESCRIPTION
### Description of the Changes

Add support for extracting mimetype for sources without flavor ids
Main difference here is that we now always parse the metadata for mimetype if we can, but working on this has surfaced many issues I bet we didn't catch yet.
I won't add this here but need to think on making all object as object literals instead of class with contractor to simplify passing them around and add test for the declared use cases, such as VOD entry, VOD with DRM, Kaltura Live, external/universal live, e.g. which is a lot better then testing partner:entryid tests. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
