### PR TITLE
fix(FEC-7647): uiConfId is 0 in the kanalytics stats

### DIFF
--- a/src/k-provider/ovp/ovp-provider.js
+++ b/src/k-provider/ovp/ovp-provider.js
@@ -86,6 +86,7 @@ export class OvpProvider {
     this.partnerID = options.partnerID;
     this.ks = options.ks;
     this._isAnonymous = !this.ks;
+    this._uiConfId = options.uiConfId;
     this._loadUiConf = options.loadUiConf;
     if (options.logLevel && this.LogLevel[options.logLevel]) {
       setLogLevel(this.LogLevel[options.logLevel]);
@@ -114,7 +115,7 @@ export class OvpProvider {
         }
         this._dataLoader.add(MediaEntryLoader, {entryId: entryId, ks: ks});
         if (this._loadUiConf) {
-          this._dataLoader.add(UiConfigLoader, {uiConfId: uiConfId, ks: ks});
+          this._dataLoader.add(UiConfigLoader, {uiConfId: this._uiConfId, ks: ks});
         }
         this._dataLoader.fetchData()
           .then(response => {


### PR DESCRIPTION
added uiConfId to the constructor and used it instead of the one we get in 'getConfig'
should I remove uiconf from the getConfig function as well? is it there for future support? is it redundant? 

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
