### PR TITLE
feat(ott-provider): filter sources by device formats

### DIFF
--- a/flow-typed/types/media-info.js
+++ b/flow-typed/types/media-info.js
@@ -8,5 +8,6 @@ declare type OTTProviderMediaInfoObject = ProviderMediaInfoObject & {
   mediaType: string,
   contextType: string,
   protocol?: string,
-  fileIds?: string
+  fileIds?: string,
+  formats?: Array<string>
 };

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -50,7 +50,7 @@ export default class BaseProvider<MI> {
     throw new TypeError(`getMediaConfig method must be implement by the derived class`);
   }
 
-  _parseDataFromResponse(data: Map<string, Function>): ProviderMediaConfigObject { // eslint-disable-line no-unused-vars
+  _parseDataFromResponse(data: Map<string, Function>, ...params: any): ProviderMediaConfigObject { // eslint-disable-line no-unused-vars
     throw new TypeError(`_parseDataFromResponse method must be implement by the derived class`);
   }
 

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -13,14 +13,15 @@ export default class OTTProviderParser extends BaseProviderParser {
   static _logger = getLogger("OTTProviderParser");
 
   /**
-   * Returns parsed media entry by given OTT response objects
+   * Returns parsed media entry by given OTT response objects.
    * @function getMediaEntry
-   * @param {any} assetResponse - The asset response
+   * @param {any} assetResponse - The asset response.
+   * @param {Object} requestData - The request data object.
    * @returns {MediaEntry} - The media entry
    * @static
    * @public
    */
-  static getMediaEntry(assetResponse: any): MediaEntry {
+  static getMediaEntry(assetResponse: any, requestData: Object): MediaEntry {
     const mediaEntry = new MediaEntry();
     const playbackContext = assetResponse.playBackContextResult;
     const metadata = assetResponse.mediaDataResult;
@@ -30,10 +31,25 @@ export default class OTTProviderParser extends BaseProviderParser {
     const metaData = {description: metadata.description};
     Object.assign(metaData, metadata.metas);
     Object.assign(metaData, metadata.tags);
+    const filteredKalturaSources = OTTProviderParser._filterSourcesByFormats(kalturaSources, requestData.formats);
+    mediaEntry.sources = OTTProviderParser._getParsedSources(filteredKalturaSources);
     mediaEntry.metadata = metaData;
-    mediaEntry.sources = OTTProviderParser._getParsedSources(kalturaSources);
     mediaEntry.duration = Math.max.apply(Math, kalturaSources.map(source => source.duration));
     return mediaEntry;
+  }
+
+  /**
+   * Filtered the kalturaSources array by device type.
+   * @param {Array<KalturaPlaybackSource>} kalturaSources - The kaltura sources.
+   * @param {Array<string>} formats - Partner device formats.
+   * @returns {Array<KalturaPlaybackSource>} - Filtered kalturaSources array.
+   * @private
+   */
+  static _filterSourcesByFormats(kalturaSources: Array<KalturaPlaybackSource>, formats: Array<string>): Array<KalturaPlaybackSource> {
+    if (formats.length > 0) {
+      kalturaSources = kalturaSources.filter(source => formats.includes(source.type));
+    }
+    return kalturaSources;
   }
 
   /**

--- a/test/src/k-provider/ott/media-config-data.js
+++ b/test/src/k-provider/ott/media-config-data.js
@@ -95,4 +95,56 @@ const NoPluginsWithDrm = {
   }
 };
 
-export {NoPluginsWithDrm};
+const FilteredSourcesByDeviceType = {
+  "id": 480097,
+  "name": "Trolls",
+  "session": {
+    "partnerId": 198,
+    "ks": "djJ8MTk4fHFNlNTFP8NV_WXoPn3CJnQRIJhCe4zD9g5voCHCgHJRanv2ubEBLLl9Gb13CxfBTGWZpTP_pD_fOirT3-L4F0kDIdJRrkShBxjuRI1-0nz2ublJJd48QKzLAqW79y7Lzoj6ngfv1uHGC7xxPtUqcSw="
+  },
+  "plugins": {},
+  "sources": {
+    "progressive": [],
+    "dash": [],
+    "hls": [{
+      "id": "728182,applehttp",
+      "url": "http://api-preprod.ott.kaltura.com/v4_6/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/480097/assetType/media/assetFileId/728182/contextType/PLAYBACK/a.m3u8",
+      "mimetype": "application/x-mpegURL",
+      "drmData": [{
+        "licenseUrl": "https://ny-udrm-stg.kaltura.com/fps/license?custom_data=eyJjYV9zeXN0ZW0iOiJodHRwOi8vYXBpLXByZXByb2Qub3R0LmthbHR1cmEuY29tL3Y0XzYvYXBpX3YzL3NlcnZpY2UvYXNzZXRGaWxlL2FjdGlvbi9nZXRDb250ZXh0P2tzPWRqSjhNVGs0ZkhGTmxOVEZQOE5WX1dYb1BuM0NKblFSSUpoQ2U0ekQ5ZzV2b0NIQ2dISlJhbnYydWJFQkxMbDlHYjEzQ3hmQlRHV1pwVFBfcERfZk9pclQzLUw0RjBrRElkSlJya1NoQnhqdVJJMS0wbnoydWJsSkpkNDhRS3pMQXFXNzl5N0x6b2o2bmdmdjF1SEdDN3h4UHRVcWNTdz0mY29udGV4dFR5cGU9bm9uZSZpZD03MjgxODIiLCJhY2NvdW50X2lkIjoyMDkxNjcxLCJjb250ZW50X2lkIjoiMV90bWVxZTJuOV8xX3V3bHphbHN6LDFfdG1lcWUybjlfMV9ob2lqMHo3NyIsImZpbGVzIjoiIiwidXNlcl90b2tlbiI6ImRqSjhNVGs0ZkhGTmxOVEZQOE5WX1dYb1BuM0NKblFSSUpoQ2U0ekQ5ZzV2b0NIQ2dISlJhbnYydWJFQkxMbDlHYjEzQ3hmQlRHV1pwVFBfcERfZk9pclQzLUw0RjBrRElkSlJya1NoQnhqdVJJMS0wbnoydWJsSkpkNDhRS3pMQXFXNzl5N0x6b2o2bmdmdjF1SEdDN3h4UHRVcWNTdz0iLCJ1ZGlkIjoiIiwiYWRkaXRpb25hbF9jYXNfc3lzdGVtIjoxOTh9&signature=Ch65ih3S1%2bIXVl7mZywrIRnSpSg%3d",
+        "scheme": "com.apple.fairplay",
+        "certificate": "MIIE6TCCA9GgAwIBAgIIENeCqzQk/C4wDQYJKoZIhvcNAQEFBQAwfzELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MTMwMQYDVQQDDCpBcHBsZSBLZXkgU2VydmljZXMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTYwNTIwMTAxNDM1WhcNMTgwNTIxMTAxNDM1WjB8MQswCQYDVQQGEwJVUzEhMB8GA1UECgwYRGFpIFRydXllbiBIaW5oIFZpZXQgTmFtMRMwEQYDVQQLDAo0NkEzVkI4S05FMTUwMwYDVQQDDCxGYWlyUGxheSBTdHJlYW1pbmc6IERhaSBUcnV5ZW4gSGluaCBWaWV0IE5hbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAxOpAcmYS8tPhh5Uk8C+0JzWy3CHJeU6odJXziTER49EEZnXHbfmIZpC1J9oMFVg6HTi5qFYgyvE19Iko7g2u0SubbM+WU6NEtzC5Mh5sjA4h3bOLSiC9lbBF9yIQiQ40Slar7EEhJRAJ1yAevMjMbAXU5YZjphamjVc0i3HB5UkCAwEAAaOCAe4wggHqMB0GA1UdDgQWBBQ1657dTf5GhGZap1ODbUTjL4AiPTAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFGPkR1TLhXFZRiyDrMxEMWRnAyy+MIHiBgNVHSAEgdowgdcwgdQGCSqGSIb3Y2QFATCBxjCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA1BgNVHR8ELjAsMCqgKKAmhiRodHRwOi8vY3JsLmFwcGxlLmNvbS9rZXlzZXJ2aWNlcy5jcmwwDgYDVR0PAQH/BAQDAgUgMDwGCyqGSIb3Y2QGDQEDAQH/BCoBcTFhMm45bWs4dWRmYWhtaWQwdmYydWh5N25hZmVxZHZoOXZob2c2b3YwMAYLKoZIhvdjZAYNAQQBAf8EHgE3eGRnd3MydWdtNDZxdGxjbGhjY2pka3J2bm56YzANBgkqhkiG9w0BAQUFAAOCAQEAP4VtMfsSO6mNAgK0AfoJgMGQ+1xhMhHYjBQdcudB3qzSznAj/u29LGPlsQW+jRB0VZJM5jBtP9n1kElo8IBnD7h1iTnHgd1v+MIGqcI+S+g5Ga+h0LmPNObHBuFVDGFqRXKv5LWI6KZ+7KNNSo4p8v7WV2JfYGDRoTtk4sA5GGw8Kyb2DNC+0+YBoZjW78Tu9fM6RanDmfMjFWpe2jQ9q9uBirOWkcVmwpNud/N61Vz3RAhmYuqYUE21R/1mLr+dBYZ54WLsI3za+bBQe3QjpYtJvJnEJIBDzXHia8Alo9KhNOGxMeexJhQXx0KM6XH2DVUf6KMrr5cH7bIdwbSCAQ=="
+      }]
+    }, {
+      "id": "728183,applehttp",
+      "url": "http://api-preprod.ott.kaltura.com/v4_6/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/480097/assetType/media/assetFileId/728183/contextType/PLAYBACK/a.m3u8",
+      "mimetype": "application/x-mpegURL",
+      "drmData": [{
+        "licenseUrl": "https://ny-udrm-stg.kaltura.com/fps/license?custom_data=eyJjYV9zeXN0ZW0iOiJodHRwOi8vYXBpLXByZXByb2Qub3R0LmthbHR1cmEuY29tL3Y0XzYvYXBpX3YzL3NlcnZpY2UvYXNzZXRGaWxlL2FjdGlvbi9nZXRDb250ZXh0P2tzPWRqSjhNVGs0ZkhGTmxOVEZQOE5WX1dYb1BuM0NKblFSSUpoQ2U0ekQ5ZzV2b0NIQ2dISlJhbnYydWJFQkxMbDlHYjEzQ3hmQlRHV1pwVFBfcERfZk9pclQzLUw0RjBrRElkSlJya1NoQnhqdVJJMS0wbnoydWJsSkpkNDhRS3pMQXFXNzl5N0x6b2o2bmdmdjF1SEdDN3h4UHRVcWNTdz0mY29udGV4dFR5cGU9bm9uZSZpZD03MjgxODMiLCJhY2NvdW50X2lkIjoyMDkxNjcxLCJjb250ZW50X2lkIjoiMV90bWVxZTJuOV8xX3V3bHphbHN6LDFfdG1lcWUybjlfMV9ob2lqMHo3NyIsImZpbGVzIjoiIiwidXNlcl90b2tlbiI6ImRqSjhNVGs0ZkhGTmxOVEZQOE5WX1dYb1BuM0NKblFSSUpoQ2U0ekQ5ZzV2b0NIQ2dISlJhbnYydWJFQkxMbDlHYjEzQ3hmQlRHV1pwVFBfcERfZk9pclQzLUw0RjBrRElkSlJya1NoQnhqdVJJMS0wbnoydWJsSkpkNDhRS3pMQXFXNzl5N0x6b2o2bmdmdjF1SEdDN3h4UHRVcWNTdz0iLCJ1ZGlkIjoiIiwiYWRkaXRpb25hbF9jYXNfc3lzdGVtIjoxOTh9&signature=lighwi6L3K093M%2fBKJeKX%2fpwaQA%3d",
+        "scheme": "com.apple.fairplay",
+        "certificate": "MIIE6TCCA9GgAwIBAgIIENeCqzQk/C4wDQYJKoZIhvcNAQEFBQAwfzELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MTMwMQYDVQQDDCpBcHBsZSBLZXkgU2VydmljZXMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTYwNTIwMTAxNDM1WhcNMTgwNTIxMTAxNDM1WjB8MQswCQYDVQQGEwJVUzEhMB8GA1UECgwYRGFpIFRydXllbiBIaW5oIFZpZXQgTmFtMRMwEQYDVQQLDAo0NkEzVkI4S05FMTUwMwYDVQQDDCxGYWlyUGxheSBTdHJlYW1pbmc6IERhaSBUcnV5ZW4gSGluaCBWaWV0IE5hbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAxOpAcmYS8tPhh5Uk8C+0JzWy3CHJeU6odJXziTER49EEZnXHbfmIZpC1J9oMFVg6HTi5qFYgyvE19Iko7g2u0SubbM+WU6NEtzC5Mh5sjA4h3bOLSiC9lbBF9yIQiQ40Slar7EEhJRAJ1yAevMjMbAXU5YZjphamjVc0i3HB5UkCAwEAAaOCAe4wggHqMB0GA1UdDgQWBBQ1657dTf5GhGZap1ODbUTjL4AiPTAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFGPkR1TLhXFZRiyDrMxEMWRnAyy+MIHiBgNVHSAEgdowgdcwgdQGCSqGSIb3Y2QFATCBxjCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA1BgNVHR8ELjAsMCqgKKAmhiRodHRwOi8vY3JsLmFwcGxlLmNvbS9rZXlzZXJ2aWNlcy5jcmwwDgYDVR0PAQH/BAQDAgUgMDwGCyqGSIb3Y2QGDQEDAQH/BCoBcTFhMm45bWs4dWRmYWhtaWQwdmYydWh5N25hZmVxZHZoOXZob2c2b3YwMAYLKoZIhvdjZAYNAQQBAf8EHgE3eGRnd3MydWdtNDZxdGxjbGhjY2pka3J2bm56YzANBgkqhkiG9w0BAQUFAAOCAQEAP4VtMfsSO6mNAgK0AfoJgMGQ+1xhMhHYjBQdcudB3qzSznAj/u29LGPlsQW+jRB0VZJM5jBtP9n1kElo8IBnD7h1iTnHgd1v+MIGqcI+S+g5Ga+h0LmPNObHBuFVDGFqRXKv5LWI6KZ+7KNNSo4p8v7WV2JfYGDRoTtk4sA5GGw8Kyb2DNC+0+YBoZjW78Tu9fM6RanDmfMjFWpe2jQ9q9uBirOWkcVmwpNud/N61Vz3RAhmYuqYUE21R/1mLr+dBYZ54WLsI3za+bBQe3QjpYtJvJnEJIBDzXHia8Alo9KhNOGxMeexJhQXx0KM6XH2DVUf6KMrr5cH7bIdwbSCAQ=="
+      }]
+    }]
+  },
+  "duration": 123000,
+  "type": "Unknown",
+  "dvr": false,
+  "metadata": {
+    "0": {"key": "Free", "value": "nirit|nirit|nirit|"},
+    "1": {"key": "Genre", "value": "Comedy|Comedy|Comedy|Drama|Kids|Kids|Kids|"},
+    "2": {
+      "key": "Main cast",
+      "value": "Anna Kendrick|Anna Kendrick|Anna Kendrick|Justin Timberlake|Justin Timberlake|Justin Timberlake|"
+    },
+    "3": {"key": "Director", "value": "Walt Dohrn|Walt Dohrn|Walt Dohrn|"},
+    "4": {"key": "Parental Rating", "value": "PG|Parental - 8|"},
+    "5": {"key": "Studio", "value": "Pixar|Pixar|Pixar|"},
+    "6": {"key": "Country", "value": "USA|USA|USA|"},
+    "7": {"key": "QUALITY", "value": "hd|hd|hd|"},
+    "8": {"key": "Release year", "value": 2017},
+    "9": {"key": "Catchup allowed", "value": false},
+    "description": "After the Bergens invade Troll Village, Poppy, the happiest Troll ever born, and the curmudgeonly Branch set off on a journey to rescue her friends. DreamWorks Animation's TROLLS is an irreverent comedy extravaganza with incredible music! From the genius creators of SHREK, TROLLS stars Anna Kendrick as Poppy, the optimistic leader of the Trolls, and her polar opposite, Branch, played by Justin Timberlake. Together, this unlikely pair of Trolls must embark on an adventure that takes them far beyond the only world they've ever known."
+  }
+};
+
+export {NoPluginsWithDrm, FilteredSourcesByDeviceType};

--- a/test/src/k-provider/ott/provider.spec.js
+++ b/test/src/k-provider/ott/provider.spec.js
@@ -40,6 +40,30 @@ describe('OTTProvider.partnerId:198', function () {
       done(err)
     })
   });
+
+  it('should return config filtered by device types', (done) => {
+    sinon.stub(MultiRequestBuilder.prototype, "execute").callsFake(
+      function () {
+        return new Promise((resolve) => {
+          const response = new MultiRequestResult(BE_DATA.AnonymousEntryWithoutUIConfWithDrmData);
+          resolve(response);
+        });
+      }
+    );
+    provider.getMediaConfig({
+      entryId: 480097,
+      formats: ["Mobile_Devices_Main_HD_FP", "Mobile_Devices_Main_SD_FP"]
+    }).then(mediaConfig => {
+      try {
+        mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.FilteredSourcesByDeviceType);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    }, err => {
+      done(err)
+    })
+  });
 });
 
 describe('logger', () => {


### PR DESCRIPTION
### Description of the Changes

Support filtering sources by device formats such as in the SDK.
We need to pass a requestData object to the provider parser with the formats array.
It also passing context & media types for decide regards LIVE/VOD (will be supported soon). 
```js
  var mediaInfo = {
    entryId: 560216,
    formats: ["HLSFPS_Mobile_SD", "HLS_360_SD"]
  };
```

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
