### PR TITLE
feat(ott-provider): return media type (live/vod)

### DIFF
--- a/test/src/k-provider/ott/media-config-data.js
+++ b/test/src/k-provider/ott/media-config-data.js
@@ -75,7 +75,7 @@ const NoPluginsWithDrm = {
     }]
   },
   "duration": 123000,
-  "type": "Unknown",
+  "type": "Vod",
   "dvr": false,
   "metadata": {
     "0": {"key": "Free", "value": "nirit|nirit|nirit|"},
@@ -127,7 +127,7 @@ const FilteredSourcesByDeviceType = {
     }]
   },
   "duration": 123000,
-  "type": "Unknown",
+  "type": "Vod",
   "dvr": false,
   "metadata": {
     "0": {"key": "Free", "value": "nirit|nirit|nirit|"},


### PR DESCRIPTION
### Description of the Changes

Return the correct media type from ott backend - LIVE (with/without DVR)/VOD.
Logic based on the SDK mobile logic.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
