### PR TITLE
fix(FEC-7828): Live videos in OTT show VOD UI

### DIFF
--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -74,10 +74,8 @@ export default class OTTProviderParser extends BaseProviderParser {
    */
   static _getMediaType(mediaAssetData: Object, mediaType: string, contextType: string): Object {
     let typeData = {type: MediaEntry.Type.UNKNOWN};
-    if (KalturaAsset.Type[mediaType] && KalturaPlaybackContext[contextType]) {
-      if (typeof MediaTypeCombinations[mediaType][contextType] === 'function') {
-        typeData = MediaTypeCombinations[mediaType][contextType](mediaAssetData);
-      }
+    if (MediaTypeCombinations[mediaType] && MediaTypeCombinations[mediaType][contextType]) {
+      typeData = MediaTypeCombinations[mediaType][contextType](mediaAssetData);
     }
     return typeData;
   }

--- a/test/src/k-provider/ott/be-data.js
+++ b/test/src/k-provider/ott/be-data.js
@@ -518,4 +518,462 @@ const AnonymousEntryWithoutUIConfWithDrmData = {
   }], "executionTime": 0.7283435
 };
 
-export {AnonymousEntryWithoutUIConfWithDrmData};
+const LiveEntryNoDrmData = {
+  "result": [
+    {
+      "ks": "djJ8MTk4fEiDJqfTA_nqary8_jB-U-W0ne3JNVaZW5JmZDufdRcmcTGy3pAquXoMvFbANe6h63lEhxCo7mMZTsMTP5k4QDmOq99dRsPEsHUwOknv_9wvR_J2pbNzdXmlZ4JlYgO0ZcUr9_7tsZhqrHRfIcgrSj4=",
+      "refreshToken": "b07f74dfe6584790b272eb742577369b",
+      "objectType": "KalturaLoginSession"
+    },
+    {
+      "externalIds": "1073",
+      "catchUpBuffer": 10080,
+      "trickPlayBuffer": 0,
+      "enableRecordingPlaybackNonEntitledChannel": true,
+      "entryId": "",
+      "id": 276507,
+      "type": 422,
+      "name": "USA",
+      "description": "***nadya_aes***",
+      "images": [
+        {
+          "ratio": "16:9",
+          "width": 153,
+          "height": 86,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/153/height/86/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 302,
+          "height": 170,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/302/height/170/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 568,
+          "height": 320,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/568/height/320/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 960,
+          "height": 540,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/960/height/540/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 1280,
+          "height": 720,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/1280/height/720/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 2048,
+          "height": 1152,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/2048/height/1152/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "1:1",
+          "width": 70,
+          "height": 70,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_12/version/0/width/70/height/70/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_12",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "1:1",
+          "width": 100,
+          "height": 100,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_12/version/0/width/100/height/100/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_12",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 103,
+          "height": 154,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/103/height/154/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 149,
+          "height": 223,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/149/height/223/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 212,
+          "height": 318,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/212/height/318/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 355,
+          "height": 534,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/355/height/534/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 800,
+          "height": 1111,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/800/height/1111/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 600,
+          "height": 900,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/600/height/900/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 282,
+          "height": 158,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/282/height/158/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:3",
+          "width": 180,
+          "height": 270,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_2/version/0/width/180/height/270/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_2",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 105,
+          "height": 80,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/105/height/80/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 195,
+          "height": 150,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/195/height/150/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 105,
+          "height": 55,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/105/height/55/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 70,
+          "height": 52,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/70/height/52/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 590,
+          "height": 445,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/590/height/445/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 300,
+          "height": 250,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/300/height/250/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "1:1",
+          "width": 500,
+          "height": 500,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_12/version/0/width/500/height/500/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_12",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "2:1",
+          "width": 200,
+          "height": 100,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_17/version/0/width/200/height/100/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_17",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "4:3",
+          "width": 400,
+          "height": 300,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_3/version/0/width/400/height/300/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_3",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "16:9",
+          "width": 1080,
+          "height": 1960,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_1/version/0/width/1080/height/1960/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_1",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        },
+        {
+          "ratio": "1:1",
+          "width": 800,
+          "height": 800,
+          "url": "http://imageserver-1655531075.eu-west-1.elb.amazonaws.com/ImageServer/Service.svc/GetImage/p/198/entry_id/6c5a2e51f3354e75b2e4fe8a5f8dab33_12/version/0/width/800/height/800/quality/100",
+          "version": 0,
+          "id": "6c5a2e51f3354e75b2e4fe8a5f8dab33_12",
+          "isDefault": false,
+          "objectType": "KalturaMediaImage"
+        }
+      ],
+      "mediaFiles": [
+        {
+          "assetId": 276507,
+          "id": 552351,
+          "type": "Mobile_Devices_Main_SD",
+          "url": "http://cdnapi.kaltura.com/p/931702/sp/93170200/playManifest/entryId/1_oorxcge2/format/applehttp/protocol/http/uiConfId/28428751/a.m3u8",
+          "duration": 0,
+          "externalId": "",
+          "fileSize": 0,
+          "objectType": "KalturaMediaFile"
+        },
+        {
+          "assetId": 276507,
+          "id": 552352,
+          "type": "Mobile_Devices_Main_HD",
+          "url": "http://cdnapi.kaltura.com/p/931702/sp/93170200/playManifest/entryId/1_oorxcge2/format/applehttp/protocol/http/uiConfId/28428751/a.m3u8",
+          "duration": 0,
+          "externalId": "",
+          "fileSize": 0,
+          "objectType": "KalturaMediaFile"
+        }
+      ],
+      "metas": {
+        "synopsis": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Short title": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Runtime": {
+          "value": "220",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Catchup logo URL": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "App Link": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Country": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "QUALITY": {
+          "value": "",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Epg ID": {
+          "value": "1073",
+          "objectType": "KalturaMultilingualStringValue"
+        },
+        "Channel number": {
+          "value": 19,
+          "objectType": "KalturaDoubleValue"
+        },
+        "Epg guid ID": {
+          "value": 1073,
+          "objectType": "KalturaDoubleValue"
+        },
+        "Catchup allowed": {
+          "value": false,
+          "objectType": "KalturaBooleanValue"
+        }
+      },
+      "tags": {
+        "Free": {
+          "objects": [
+            {
+              "value": "yes",
+              "objectType": "KalturaMultilingualStringValue"
+            },
+            {
+              "value": "no",
+              "objectType": "KalturaMultilingualStringValue"
+            }
+          ],
+          "objectType": "KalturaMultilingualStringValueArray"
+        },
+        "Genre": {
+          "objects": [
+            {
+              "value": "History",
+              "objectType": "KalturaMultilingualStringValue"
+            }
+          ],
+          "objectType": "KalturaMultilingualStringValueArray"
+        },
+        "Parental Rating": {
+          "objects": [
+            {
+              "value": "PG",
+              "objectType": "KalturaMultilingualStringValue"
+            }
+          ],
+          "objectType": "KalturaMultilingualStringValueArray"
+        },
+        "QUALITY": {
+          "objects": [
+            {
+              "value": "hd",
+              "objectType": "KalturaMultilingualStringValue"
+            }
+          ],
+          "objectType": "KalturaMultilingualStringValueArray"
+        },
+        "Source": {
+          "objects": [
+            {
+              "value": "Web3",
+              "objectType": "KalturaMultilingualStringValue"
+            }
+          ],
+          "objectType": "KalturaMultilingualStringValueArray"
+        }
+      },
+      "startDate": 946684800,
+      "endDate": 2524608000,
+      "enableCdvr": true,
+      "enableCatchUp": true,
+      "enableStartOver": true,
+      "enableTrickPlay": true,
+      "objectType": "KalturaMediaAsset"
+    },
+    {
+      "sources": [
+        {
+          "format": "applehttp",
+          "protocols": "http",
+          "drm": [],
+          "assetId": 276507,
+          "id": 552351,
+          "type": "Mobile_Devices_Main_SD",
+          "url": "http://api-preprod.ott.kaltura.com/v4_7/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/276507/assetType/media/assetFileId/552351/contextType/PLAYBACK/a.m3u8",
+          "duration": 0,
+          "externalId": "",
+          "fileSize": 0,
+          "objectType": "KalturaPlaybackSource"
+        },
+        {
+          "format": "applehttp",
+          "protocols": "http",
+          "drm": [],
+          "assetId": 276507,
+          "id": 552352,
+          "type": "Mobile_Devices_Main_HD",
+          "url": "http://api-preprod.ott.kaltura.com/v4_7/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/276507/assetType/media/assetFileId/552352/contextType/PLAYBACK/a.m3u8",
+          "duration": 0,
+          "externalId": "",
+          "fileSize": 0,
+          "objectType": "KalturaPlaybackSource"
+        }
+      ],
+      "messages": [
+        {
+          "message": "OK",
+          "code": "OK",
+          "objectType": "KalturaAccessControlMessage"
+        }
+      ],
+      "objectType": "KalturaPlaybackContext"
+    }
+  ],
+  "executionTime": 0.3984844
+};
+
+export {AnonymousEntryWithoutUIConfWithDrmData, LiveEntryNoDrmData};

--- a/test/src/k-provider/ott/media-config-data.js
+++ b/test/src/k-provider/ott/media-config-data.js
@@ -147,4 +147,80 @@ const FilteredSourcesByDeviceType = {
   }
 };
 
-export {NoPluginsWithDrm, FilteredSourcesByDeviceType};
+const LiveEntryNoDrm = {
+  "id": 276507,
+  "name": "USA",
+  "session": {
+    "partnerId": 198,
+    "ks": "djJ8MTk4fEiDJqfTA_nqary8_jB-U-W0ne3JNVaZW5JmZDufdRcmcTGy3pAquXoMvFbANe6h63lEhxCo7mMZTsMTP5k4QDmOq99dRsPEsHUwOknv_9wvR_J2pbNzdXmlZ4JlYgO0ZcUr9_7tsZhqrHRfIcgrSj4="
+  },
+  "sources": {
+    "progressive": [],
+    "dash": [],
+    "hls": [
+      {
+        "id": "552351,applehttp",
+        "url": "http://api-preprod.ott.kaltura.com/v4_7/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/276507/assetType/media/assetFileId/552351/contextType/PLAYBACK/a.m3u8",
+        "mimetype": "application/x-mpegURL"
+      },
+      {
+        "id": "552352,applehttp",
+        "url": "http://api-preprod.ott.kaltura.com/v4_7/api_v3/service/assetFile/action/playManifest/partnerId/198/assetId/276507/assetType/media/assetFileId/552352/contextType/PLAYBACK/a.m3u8",
+        "mimetype": "application/x-mpegURL"
+      }
+    ]
+  },
+  "duration": 0,
+  "type": "Live",
+  "dvr": false,
+  "metadata": {
+    "0": {
+      "key": "Free",
+      "value": "yes|no|"
+    },
+    "1": {
+      "key": "Genre",
+      "value": "History|"
+    },
+    "2": {
+      "key": "Parental Rating",
+      "value": "PG|"
+    },
+    "3": {
+      "key": "QUALITY",
+      "value": "hd|"
+    },
+    "4": {
+      "key": "Source",
+      "value": "Web3|"
+    },
+    "5": {
+      "key": "Country",
+      "value": ""
+    },
+    "6": {
+      "key": "QUALITY",
+      "value": ""
+    },
+    "7": {
+      "key": "Epg ID",
+      "value": "1073"
+    },
+    "8": {
+      "key": "Channel number",
+      "value": 19
+    },
+    "9": {
+      "key": "Epg guid ID",
+      "value": 1073
+    },
+    "10": {
+      "key": "Catchup allowed",
+      "value": false
+    },
+    "description": "***nadya_aes***"
+  },
+  "plugins": {}
+};
+
+export {NoPluginsWithDrm, FilteredSourcesByDeviceType, LiveEntryNoDrm};

--- a/test/src/k-provider/ott/provider.spec.js
+++ b/test/src/k-provider/ott/provider.spec.js
@@ -64,6 +64,28 @@ describe('OTTProvider.partnerId:198', function () {
       done(err)
     })
   });
+
+  it('should return entry of live type', (done) => {
+    sinon.stub(MultiRequestBuilder.prototype, "execute").callsFake(
+      function () {
+        return new Promise((resolve) => {
+          const response = new MultiRequestResult(BE_DATA.LiveEntryNoDrmData);
+          resolve(response);
+        });
+      }
+    );
+    provider.getMediaConfig({entryId: 276507})
+      .then(mediaConfig => {
+        try {
+          mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.LiveEntryNoDrm);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }, err => {
+        done(err)
+      })
+  });
 });
 
 describe('logger', () => {


### PR DESCRIPTION
### Description of the Changes

Fix the logic of checking live entry on OTT.
Now we're checking whether the response contains `externalIds` or its type of  `KalturaLinearMediaAsset`.
Logic is similar to [SDK logic](https://github.com/kaltura/playkit-android/blob/develop/playkit/src/main/java/com/kaltura/playkit/mediaproviders/ott/PhoenixMediaProvider.java#L484)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
