### PR TITLE
fix(FEC-8555): phoenix provider live detection

### DIFF
--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -17,7 +17,7 @@ const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if ((mediaAssetData.externalIds && mediaAssetData.externalIds !== '0') || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if (mediaAssetData.externalIds === '0' || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: 0};
       }
       return {type: MediaEntry.Type.VOD};

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -17,7 +17,7 @@ const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if (parseInt(mediaAssetData.externalIds) > 0) || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if (parseInt(mediaAssetData.externalIds) > 0 || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: 0};
       }
       return {type: MediaEntry.Type.VOD};

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -17,7 +17,7 @@ const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if (mediaAssetData.externalIds === '0' || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if (parseInt(mediaAssetData.externalIds) > 0) || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: 0};
       }
       return {type: MediaEntry.Type.VOD};

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -11,13 +11,13 @@ import {SupportedStreamFormat} from '../../entities/media-format';
 import KalturaDrmPlaybackPluginData from '../common/response-types/kaltura-drm-playback-plugin-data';
 import BaseProviderParser from '../common/base-provider-parser';
 
-const LIVE_ASST_OBJECT_TYPE: string = 'KalturaLinearMediaAsset';
+const LIVE_ASST_OBJECT_TYPE: string = 'KalturaLiveAsset';
 
 const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if (mediaAssetData.externalIds || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if (mediaAssetData.externalIds !== '0' || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: 0};
       }
       return {type: MediaEntry.Type.VOD};

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -17,7 +17,7 @@ const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if (mediaAssetData.externalIds !== '0' || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if ((mediaAssetData.externalIds && mediaAssetData.externalIds !== '0') || mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: 0};
       }
       return {type: MediaEntry.Type.VOD};


### PR DESCRIPTION
### Description of the Changes

From Phoenix 5.1 
the API will result in new Object Type that expose live Media involved and should named "KalturaLiveAsset" instead of "KalturaLinearMediaAsset" that is not relevant any more.

As well as checking that externalIds not containing the string "0".