### PR TITLE
feat(FEC-8541): add redirectFromEntryId configuration

### DIFF
--- a/flow-typed/types/filter-options.js
+++ b/flow-typed/types/filter-options.js
@@ -1,0 +1,4 @@
+// @flow
+declare type ProviderFilterOptionsObject = {
+  redirectFromEntryId?: boolean;
+};

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -4,5 +4,6 @@ declare type ProviderOptionsObject = {
   logLevel?: string,
   ks?: string,
   uiConfId?: number,
-  env?: ProviderEnvConfigObject
+  env?: ProviderEnvConfigObject,
+  filterOptions: ProviderFilterOptionsObject
 };

--- a/src/k-provider/ovp/loaders/entry-list-loader.js
+++ b/src/k-provider/ovp/loaders/entry-list-loader.js
@@ -53,7 +53,7 @@ export default class OVPEntryListLoader implements ILoader {
     const config = OVPConfiguration.get();
     const requests: Array<RequestBuilder> = [];
     params.entries.forEach(entryId => {
-      requests.push(OVPBaseEntryService.list(config.serviceUrl, params.ks, entryId));
+      requests.push(OVPBaseEntryService.list(config.serviceUrl, params.ks, entryId, params.filterOptions.redirectFromEntryId));
     });
     return requests;
   }

--- a/src/k-provider/ovp/loaders/media-entry-loader.js
+++ b/src/k-provider/ovp/loaders/media-entry-loader.js
@@ -54,7 +54,7 @@ export default class OVPMediaEntryLoader implements ILoader {
   buildRequests(params: Object): Array<RequestBuilder> {
     const config = OVPConfiguration.get();
     const requests: Array<RequestBuilder> = [];
-    requests.push(OVPBaseEntryService.list(config.serviceUrl, params.ks, params.entryId));
+    requests.push(OVPBaseEntryService.list(config.serviceUrl, params.ks, params.entryId, params.filterOptions.redirectFromEntryId));
     requests.push(OVPBaseEntryService.getPlaybackContext(config.serviceUrl, params.ks, params.entryId));
     requests.push(OVPMetadataService.list(config.serviceUrl, params.ks, params.entryId));
     return requests;

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -11,6 +11,8 @@ import MediaEntry from '../../entities/media-entry';
 import OVPEntryListLoader from './loaders/entry-list-loader';
 
 export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
+  _filterOptions: ProviderFilterOptionsObject = {redirectFromEntryId: true};
+
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -20,6 +22,7 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
     super(options, playerVersion);
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
+    this._setFilterOptionsConfig(options);
   }
 
   /**
@@ -40,7 +43,7 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {partnerId: this.partnerId});
         }
-        this._dataLoader.add(OVPMediaEntryLoader, {entryId, ks});
+        this._dataLoader.add(OVPMediaEntryLoader, {entryId, ks, filterOptions: this._filterOptions});
         this._dataLoader.fetchData().then(
           response => {
             resolve(this._parseDataFromResponse(response));
@@ -53,6 +56,12 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
         reject({success: false, data: 'Missing mandatory parameter'});
       }
     });
+  }
+
+  _setFilterOptionsConfig(options: ProviderOptionsObject): void {
+    if (options.filterOptions && typeof options.filterOptions.redirectFromEntryId === 'boolean') {
+      this._filterOptions.redirectFromEntryId = options.filterOptions.redirectFromEntryId;
+    }
   }
 
   _parseDataFromResponse(data: Map<string, Function>): ProviderMediaConfigObject {
@@ -163,7 +172,7 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {partnerId: this.partnerId});
         }
-        this._dataLoader.add(OVPEntryListLoader, {entries, ks});
+        this._dataLoader.add(OVPEntryListLoader, {entries, ks, filterOptions: this._filterOptions});
         this._dataLoader.fetchData().then(
           response => {
             resolve(this._parseEntryListDataFromResponse(response));

--- a/src/k-provider/ovp/services/base-entry-service.js
+++ b/src/k-provider/ovp/services/base-entry-service.js
@@ -35,10 +35,11 @@ export default class OVPBaseEntryService extends OVPService {
    * @param {string} serviceUrl The base URL
    * @param {string} ks The ks
    * @param {string} entryId The entry ID
+   * @param {boolean} redirectFromEntryId If the live entry should be redirected to the vod one after it ends or not
    * @returns {RequestBuilder} The request builder
    * @static
    */
-  static list(serviceUrl: string, ks: string, entryId: string): RequestBuilder {
+  static list(serviceUrl: string, ks: string, entryId: string, redirectFromEntryId: boolean): RequestBuilder {
     const headers: Map<string, string> = new Map();
     headers.set('Content-Type', 'application/json');
     const request = new RequestBuilder(headers);
@@ -47,7 +48,7 @@ export default class OVPBaseEntryService extends OVPService {
     request.method = 'POST';
     request.url = request.getUrl(serviceUrl);
     request.tag = 'list';
-    request.params = OVPBaseEntryService.getEntryListReqParams(entryId, ks);
+    request.params = OVPBaseEntryService.getEntryListReqParams(entryId, ks, redirectFromEntryId);
     return request;
   }
 
@@ -56,11 +57,12 @@ export default class OVPBaseEntryService extends OVPService {
    * @function getEntryListReqParams
    * @param {string} entryId The entry ID
    * @param {string} ks The ks
+   * @param {boolean} redirectFromEntryId If the live entry should be redirected to the vod one after it ends or not
    * @returns {{ks: string, filter: {redirectFromEntryId: string}, responseProfile: {fields: string, type: number}}} The service params object
    * @static
    */
-  static getEntryListReqParams(entryId: string, ks: string): any {
-    const filterParams = {redirectFromEntryId: entryId};
+  static getEntryListReqParams(entryId: string, ks: string, redirectFromEntryId: boolean): any {
+    const filterParams = redirectFromEntryId ? {redirectFromEntryId: entryId} : {idEqual: entryId};
     return {ks: ks, filter: filterParams, responseProfile: new BaseEntryResponseProfile()};
   }
 }


### PR DESCRIPTION
### Description of the Changes

A new configuration property, for cases you want to only stream the live stream, and not redirect to it's VOD after it ends.
This can be achieved by setting the filter section sent in the multirequest.
The new configuration is under the provider config:
```
filterOptions:{
   redirectFromEntryId: boolean
}
```
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
