### PR TITLE
fix(FEC-8679): setting KS only on getMediaConfig counts as anonymous session

### DIFF
--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -33,6 +33,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
   getMediaConfig(mediaInfo: OTTProviderMediaInfoObject): Promise<ProviderMediaConfigObject> {
     if (mediaInfo.ks) {
       this.ks = mediaInfo.ks;
+      this._isAnonymous = false;
     }
     this._dataLoader = new OTTDataLoaderManager(this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -35,6 +35,7 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
   getMediaConfig(mediaInfo: ProviderMediaInfoObject): Promise<ProviderMediaConfigObject> {
     if (mediaInfo.ks) {
       this.ks = mediaInfo.ks;
+      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -221,6 +221,45 @@ describe('OVPProvider.partnerId:1068292', function() {
   });
 });
 
+describe('getMediaConfig', function() {
+  let provider, sandbox;
+  const partnerId = 1068292;
+  const ks =
+    'NTAwZjViZWZjY2NjNTRkNGEyMjU1MTg4OGE1NmUwNDljZWJkMzk1MXwxMDY4MjkyOzEwNjgyOTI7MTQ5MDE3NjE0NjswOzE0OTAwODk3NDYuMDIyNjswO3ZpZXc6Kix3aWRnZXQ6MTs7';
+  const playerVersion = '1.2.3';
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    provider = new OVPProvider({partnerId: partnerId}, playerVersion);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    MultiRequestBuilder.prototype.execute.restore();
+  });
+
+  it('should set anonymous to false when given a KS', done => {
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfWithDrmData.response)});
+      });
+    });
+    provider.getMediaConfig({entryId: '1_rwbj3j0a', ks: ks}).then(
+      mediaConfig => {
+        try {
+          mediaConfig.session.isAnonymous.should.be.false;
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
+});
+
 describe('logger', () => {
   const partnerId = 1068292;
   const playerVersion = '1.2.3';


### PR DESCRIPTION
### Description of the Changes

If session is only passed on `getMediaConfig` and on the provider constructor then the `isAnonymous` session flag is not set to false.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
