### PR TITLE
fix: 'networkRetryParameters' type causes KalturaPlayerJS build (flow) to fail

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,8 +28,9 @@ var provider = new playkit.providers.ott.Provider(config);
   logLevel: string, // optional
   ks: string, // optional
   uiConfId: number, // optional
-  env: ProviderEnvConfigObject // optional
-  filterOptions: ProviderFilterOptionsObject //optional
+  env: ProviderEnvConfigObject, // optional
+  networkRetryParameters: ProviderNetworkRetryParameters, // optional
+  filterOptions: ProviderFilterOptionsObject // optional
 }
 ```
 
@@ -111,6 +112,35 @@ var provider = new playkit.providers.ott.Provider(config);
 > ##### Description: Defines the server environment to run against.
 
 ##
+
+> ### config.networkRetryParameters
+>
+> ##### Type: `ProviderNetworkRetryParameters`
+>
+> ```js
+> {
+>  timeout?: number,
+>  maxAttempts?: number
+> }
+> ```
+>
+> > ### config.networkRetryParameters.timeout
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `0` - this means it will use the browser default timeout.
+> >
+> > ##### Description: Defines the timeout for the provider requests in milliseconds.
+>
+> ##
+>
+> > ### config.networkRetryParameters.maxAttempts
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `4`
+> >
+> > ##### Description: Defines the number of attemps the providers should try make a request before it fails.
 
 > ### config.filterOptions
 >

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -5,6 +5,6 @@ declare type ProviderOptionsObject = {
   ks?: string,
   uiConfId?: number,
   env?: ProviderEnvConfigObject,
-  networkRetryParameters: ProviderNetworkRetryParameters,
+  networkRetryParameters?: ProviderNetworkRetryParameters,
   filterOptions?: ProviderFilterOptionsObject
 };

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -10,6 +10,10 @@ export default class BaseProvider<MI> {
   _playerVersion: string;
   _logger: any;
   _isAnonymous: boolean;
+  _networkRetryConfig: ProviderNetworkRetryParameters = {
+    timeout: 0,
+    maxAttempts: 4
+  };
 
   get partnerId(): number {
     return this._partnerId;

--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -29,13 +29,10 @@ export default class DataLoaderManager {
    */
   _loaders: Map<string, ILoader> = new Map();
 
-  _networkRetryConfig: ProviderNetworkRetryParameters = {
-    timeout: 0,
-    maxAttempts: 4
-  };
+  _networkRetryConfig: ProviderNetworkRetryParameters;
 
-  constructor(networkRetryConfig?: ProviderNetworkRetryParameters) {
-    Object.assign(this._networkRetryConfig, networkRetryConfig);
+  constructor(networkRetryConfig: ProviderNetworkRetryParameters) {
+    this._networkRetryConfig = networkRetryConfig;
   }
 
   /**

--- a/src/k-provider/ott/loaders/data-loader-manager.js
+++ b/src/k-provider/ott/loaders/data-loader-manager.js
@@ -8,7 +8,7 @@ import OTTService from '../services/ott-service';
  * @param {ProviderNetworkRetryParameters} [networkRetryConfig] - network retry configuration
  */
 export default class OTTDataLoaderManager extends DataLoaderManager {
-  constructor(partnerId: number, ks: string = '', networkRetryConfig?: ProviderNetworkRetryParameters) {
+  constructor(partnerId: number, ks: string = '', networkRetryConfig: ProviderNetworkRetryParameters) {
     super(networkRetryConfig);
     this._multiRequest = OTTService.getMultiRequest(ks, partnerId);
   }

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -12,7 +12,6 @@ import MediaEntry from '../../entities/media-entry';
 import Error from '../../util/error/error';
 
 export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject> {
-  _networkRetryConfig: ProviderNetworkRetryParameters;
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -22,7 +21,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
     super(options, playerVersion);
     this._logger = getLogger('OTTProvider');
     OTTConfiguration.set(options.env);
-    this._networkRetryConfig = options.networkRetryParameters || {};
+    this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
   }
 
   /**

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -22,7 +22,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
     super(options, playerVersion);
     this._logger = getLogger('OTTProvider');
     OTTConfiguration.set(options.env);
-    this._networkRetryConfig = options.networkRetryParameters;
+    this._networkRetryConfig = options.networkRetryParameters || {};
   }
 
   /**

--- a/src/k-provider/ovp/loaders/data-loader-manager.js
+++ b/src/k-provider/ovp/loaders/data-loader-manager.js
@@ -10,7 +10,7 @@ import OVPService from '../services/ovp-service';
  * @param {ProviderNetworkRetryParameters} [networkRetryConfig] - network retry configuration
  */
 export default class OVPDataLoaderManager extends DataLoaderManager {
-  constructor(playerVersion: string, partnerId: number, ks: string = '', networkRetryConfig?: ProviderNetworkRetryParameters) {
+  constructor(playerVersion: string, partnerId: number, ks: string = '', networkRetryConfig: ProviderNetworkRetryParameters) {
     super(networkRetryConfig);
     this._multiRequest = OVPService.getMultiRequest(playerVersion, ks, partnerId);
   }

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -13,7 +13,6 @@ import Error from '../../util/error/error';
 
 export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
   _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
-  _networkRetryConfig: ProviderNetworkRetryParameters;
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -23,8 +22,8 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
     super(options, playerVersion);
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
-    this._networkRetryConfig = options.networkRetryParameters || {};
     this._setFilterOptionsConfig(options.filterOptions);
+    this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
   }
 
   /**

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -23,7 +23,7 @@ export default class OVPProvider extends BaseProvider<ProviderMediaInfoObject> {
     super(options, playerVersion);
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
-    this._networkRetryConfig = options.networkRetryParameters;
+    this._networkRetryConfig = options.networkRetryParameters || {};
     this._setFilterOptionsConfig(options.filterOptions);
   }
 


### PR DESCRIPTION
### Description of the Changes

fix flow type impact KalturaPlayerJS.
add missing retryNetwork configuration.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
