### PR TITLE
fix(FEC-8858): the captions in languages list displayed twice

### DIFF
--- a/src/k-provider/ovp/external-captions-builder.js
+++ b/src/k-provider/ovp/external-captions-builder.js
@@ -18,7 +18,7 @@ class ExternalCaptionsBuilder {
       return {
         default: caption.isDefault,
         type: CaptionsFormatsMap[caption.format],
-        language: caption.language,
+        language: caption.languageCode,
         label: caption.label,
         url: caption.url
       };


### PR DESCRIPTION
### Description of the Changes

change `caption.language` to `languageCode (instead of `language`)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
