### PR TITLE
feat(FEC-8875): when an external caption format is DFXP return the webvtt url

### DIFF
--- a/src/k-provider/ovp/external-captions-builder.js
+++ b/src/k-provider/ovp/external-captions-builder.js
@@ -14,13 +14,19 @@ const CaptionsFormatsMap: {[format: string]: string} = {
 
 class ExternalCaptionsBuilder {
   static createConfig(captions: Array<Object>): Array<PKExternalCaptionObject> {
-    return captions.filter(caption => [KalturaCaptionType.WEBVTT, KalturaCaptionType.SRT].includes(caption.format)).map(caption => {
+    return captions.map(caption => {
+      let url = caption.url;
+      let type = CaptionsFormatsMap[caption.format];
+      if ([KalturaCaptionType.DFXP, KalturaCaptionType.CAP].includes(caption.format)) {
+        url = caption.webVttUrl;
+        type = CaptionsFormatsMap[KalturaCaptionType.WEBVTT];
+      }
       return {
-        default: caption.isDefault,
-        type: CaptionsFormatsMap[caption.format],
+        default: caption.isDefault ? caption.isDefault : false,
+        type: type,
         language: caption.languageCode,
         label: caption.label,
-        url: caption.url
+        url: url
       };
     });
   }

--- a/src/k-provider/ovp/external-captions-builder.js
+++ b/src/k-provider/ovp/external-captions-builder.js
@@ -22,7 +22,7 @@ class ExternalCaptionsBuilder {
         type = CaptionsFormatsMap[KalturaCaptionType.WEBVTT];
       }
       return {
-        default: caption.isDefault ? caption.isDefault : false,
+        default: !!caption.isDefault,
         type: type,
         language: caption.languageCode,
         label: caption.label,

--- a/test/src/k-provider/ovp/external-captions-builder.spec.js
+++ b/test/src/k-provider/ovp/external-captions-builder.spec.js
@@ -1,0 +1,59 @@
+import {ExternalCaptionsBuilder} from '../../../../src/k-provider/ovp/external-captions-builder';
+
+describe('external captions parser', function() {
+  const playbackCaptions = [
+    {
+      format: '1',
+      label: 'Eng',
+      language: 'English',
+      languageCode: 'EN',
+      objectType: 'KalturaCaptionPlaybackPluginData',
+      url: 'regularUrl',
+      webVttUrl: 'webVttUrl'
+    },
+    {
+      format: '3',
+      label: 'FRA',
+      language: 'FRENCH',
+      languageCode: 'FR',
+      objectType: 'KalturaCaptionPlaybackPluginData',
+      url: 'regularUrl',
+      webVttUrl: 'webVttUrl'
+    },
+    {
+      format: '2',
+      label: 'RUS',
+      language: 'Russian',
+      languageCode: 'RU',
+      objectType: 'KalturaCaptionPlaybackPluginData',
+      url: 'regularUrl',
+      webVttUrl: 'webVttUrl'
+    }
+  ];
+
+  describe('createConfig', () => {
+    it('should return an empty config', () => {
+      const captions = ExternalCaptionsBuilder.createConfig([]);
+      captions.length.should.equal(0);
+    });
+    it('should return an array with 3 captions', () => {
+      const captions = ExternalCaptionsBuilder.createConfig(playbackCaptions);
+      captions.length.should.equal(3);
+    });
+    it('should return a caption with regular url with srt type', () => {
+      const captions = ExternalCaptionsBuilder.createConfig([playbackCaptions[0]]);
+      captions[0].url.should.equal('regularUrl');
+      captions[0].type.should.equal('srt');
+    });
+    it('should return a caption with regular url with vtt type', () => {
+      const captions = ExternalCaptionsBuilder.createConfig([playbackCaptions[1]]);
+      captions[0].url.should.equal('regularUrl');
+      captions[0].type.should.equal('vtt');
+    });
+    it('should return a caption with url : webvtturl with a vtt type', () => {
+      const captions = ExternalCaptionsBuilder.createConfig([playbackCaptions[2]]);
+      captions[0].url.should.equal('webVttUrl');
+      captions[0].type.should.equal('vtt');
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Changes

use `webvtturl` when the caption format is DFXP or CAP.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
