### PR TITLE
fix(FEC-8935): Unable to play remote flavors

### DIFF
--- a/src/k-provider/ovp/play-source-url-builder.js
+++ b/src/k-provider/ovp/play-source-url-builder.js
@@ -26,7 +26,7 @@ export default class PlaySourceUrlBuilder {
     const {partnerId, entryId, ks, uiConfId, format, protocol, extension, flavorIds} = urlParams;
 
     //verify mandatory params
-    if (!cdnUrl || !partnerId || !entryId || !extension || !format || !protocol || !extension) {
+    if (!cdnUrl || !partnerId || !entryId || !format || !protocol) {
       return '';
     }
 
@@ -46,7 +46,9 @@ export default class PlaySourceUrlBuilder {
       playUrl += '/ks/' + ks;
     }
 
-    playUrl += '/a.' + extension;
+    if (extension !== '') {
+      playUrl += '/a.' + extension;
+    }
 
     if (uiConfId && flavorIds !== '') {
       playUrl += '?uiConfId=' + uiConfId;


### PR DESCRIPTION
### Description of the Changes

Removed the `extension` field from the mandatory params check, as in some use cases the fileExt are returning empty. 

In addition, added a check that will add the fileExt field if it exists.

### CheckLists

- [V] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [V] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
