### PR TITLE
feat(FEC-8974): add async config option for XHR

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ var provider = new playkit.providers.ott.Provider(config);
 > >
 > > ##### Type: `boolean`
 > >
-> > ##### Default: `true` - if XMLHttpRequest is async or sync, true is async.
+> > ##### Default: `true`
 > >
 > > ##### Description: Defines whether or not to perform the request operation asynchronously.
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,10 +129,21 @@ var provider = new playkit.providers.ott.Provider(config);
 >
 > ```js
 > {
+>  async?: boolean,
 >  timeout?: number,
 >  maxAttempts?: number
 > }
 > ```
+>
+> > ### config.networkRetryParameters.async
+> >
+> > ##### Type: `boolean`
+> >
+> > ##### Default: `true` - if XMLHttpRequest is async or sync, true is async.
+> >
+> > ##### Description: Defines whether or not to perform the request operation asynchronously.
+>
+> ##
 >
 > > ### config.networkRetryParameters.timeout
 > >

--- a/flow-typed/types/network-retry-parameters.js
+++ b/flow-typed/types/network-retry-parameters.js
@@ -1,5 +1,6 @@
 // @flow
 declare type ProviderNetworkRetryParameters = {
+  async?: boolean,
   timeout?: number,
   maxAttempts?: number
 };

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -13,6 +13,7 @@ export default class BaseProvider<MI> {
   _logger: any;
   _isAnonymous: boolean;
   _networkRetryConfig: ProviderNetworkRetryParameters = {
+    async: true,
     timeout: 0,
     maxAttempts: 4
   };

--- a/src/util/request-builder.js
+++ b/src/util/request-builder.js
@@ -128,8 +128,10 @@ export default class RequestBuilder {
         }
       }
     };
-    request.open(this.method, this.url);
-    request.timeout = this.retryConfig.timeout || 0;
+    request.open(this.method, this.url, this.retryConfig.async);
+    if (this.retryConfig.async && this.retryConfig.timeout) {
+      request.timeout = this.retryConfig.timeout;
+    }
     const requestTime = performance.now();
     request.ontimeout = () => {
       this._handleError(request, Error.Code.TIMEOUT, {


### PR DESCRIPTION
### Description of the Changes

default XHR request is async, but can be set to be sync.
If set to sync then don't allow setting timeout value to prevent error:
```
DOMException: Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document
```

new config option can be set under `networkRetryParameters`
```javascript
new playkit.providers.ovp.Provider(
  {
    partnerId: 12345, 
    networkRetryParameters: {
      async:false, 
      timeout: 2000
    }
  }, 
  'myPlayerVersion');
```
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
