### PR TITLE
fix(FEC-8978): multiple players doing multi requests simultaneously may fail

### DIFF
--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -7,9 +7,8 @@ export default class DataLoaderManager {
    * @member - Loaders response map index
    * @type {Map<string,Array<number>>}
    * @private
-   * @static
    */
-  static _loadersResponseMap: Map<string, Array<number>> = new Map();
+  _loadersResponseMap: Map<string, Array<number>> = new Map();
   /**
    * @member - Loaders multi request
    * @type {MultiRequestBuilder}
@@ -58,7 +57,7 @@ export default class DataLoaderManager {
       // Create range array of current execution_loader requests
       let executionLoaderResponseMap = Array.from(new Array(requests.length), (val, index) => index + startIndex);
       // Add to map
-      DataLoaderManager._loadersResponseMap.set(loader.id, executionLoaderResponseMap);
+      this._loadersResponseMap.set(loader.id, executionLoaderResponseMap);
     }
   }
 
@@ -97,8 +96,8 @@ export default class DataLoaderManager {
    * @returns {Object} - The prepared data
    */
   prepareData(response: MultiRequestResult): Object {
-    this._loaders.forEach(function(loader, name) {
-      let loaderDataIndexes = DataLoaderManager._loadersResponseMap.get(name);
+    this._loaders.forEach((loader, name) => {
+      let loaderDataIndexes = this._loadersResponseMap.get(name);
       try {
         if (loaderDataIndexes && loaderDataIndexes.length > 0) {
           loader.response = response.results.slice(loaderDataIndexes[0], loaderDataIndexes[loaderDataIndexes.length - 1] + 1);

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -99,8 +99,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
       if (data.has(OTTSessionLoader.id)) {
         const sessionLoader = data.get(OTTSessionLoader.id);
         if (sessionLoader && sessionLoader.response) {
-          this.ks = sessionLoader.response;
-          mediaConfig.session.ks = this.ks;
+          mediaConfig.session.ks = sessionLoader.response;
         }
       } else {
         mediaConfig.session.ks = this.ks;

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -97,8 +97,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
       if (data.has(OVPSessionLoader.id)) {
         const sessionLoader = data.get(OVPSessionLoader.id);
         if (sessionLoader && sessionLoader.response) {
-          this.ks = sessionLoader.response;
-          mediaConfig.session.ks = this.ks;
+          mediaConfig.session.ks = sessionLoader.response;
         }
       } else {
         mediaConfig.session.ks = this.ks;


### PR DESCRIPTION
### Description of the Changes

The providers share the `_loadersResponseMap` on the statics of the provider and having multiple providers in different states may affect each other.
This also fixes an issue where provider saves KS from response of an anonymous request.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
