### PR TITLE
chore(FEC-9054): expose umd named define for requireJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ const baseConfig = {
   output: {
     path: path.join(__dirname, 'dist'),
     libraryTarget: 'umd',
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './providers/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
added umdNamedDefine: true to webpack.config.js to support umd named define for requireJS