### PR TITLE
fix(FEC-9212): support redirectFromEntryId logic

### DIFF
--- a/src/k-provider/ovp/loaders/media-entry-loader.js
+++ b/src/k-provider/ovp/loaders/media-entry-loader.js
@@ -64,7 +64,7 @@ export default class OVPMediaEntryLoader implements ILoader {
     const config = OVPConfiguration.get();
     const requests: Array<RequestBuilder> = [];
     requests.push(OVPBaseEntryService.list(config.serviceUrl, params.ks, params.entryId, params.redirectFromEntryId));
-    requests.push(OVPBaseEntryService.getPlaybackContext(config.serviceUrl, params.ks, params.entryId));
+    requests.push(OVPBaseEntryService.getPlaybackContext(config.serviceUrl, params.ks));
     requests.push(OVPMetadataService.list(config.serviceUrl, params.ks, params.entryId));
     return requests;
   }

--- a/src/k-provider/ovp/services/base-entry-service.js
+++ b/src/k-provider/ovp/services/base-entry-service.js
@@ -16,7 +16,7 @@ export default class OVPBaseEntryService extends OVPService {
    */
   static getPlaybackContext(serviceUrl: string, ks: string): RequestBuilder {
     const headers: Map<string, string> = new Map();
-    const baseEntryServiceEntryId = ks === '{1:result:ks}' ? '{2:result:objects:0:id}' : '{1:result:objects:0:id}';
+    const serviceEntryId = ks === '{1:result:ks}' ? '{2:result:objects:0:id}' : '{1:result:objects:0:id}';
     headers.set('Content-Type', 'application/json');
     const request = new RequestBuilder(headers);
     request.service = SERVICE_NAME;
@@ -25,7 +25,7 @@ export default class OVPBaseEntryService extends OVPService {
     request.url = request.getUrl(serviceUrl);
     request.tag = 'baseEntry-getPlaybackContext';
     const contextDataParams = {objectType: 'KalturaContextDataParams', flavorTags: 'all'};
-    request.params = {entryId: baseEntryServiceEntryId, ks: ks, contextDataParams: contextDataParams};
+    request.params = {entryId: serviceEntryId, ks: ks, contextDataParams: contextDataParams};
     return request;
   }
 

--- a/src/k-provider/ovp/services/base-entry-service.js
+++ b/src/k-provider/ovp/services/base-entry-service.js
@@ -11,12 +11,12 @@ export default class OVPBaseEntryService extends OVPService {
    * @function getPlaybackContext
    * @param {string} serviceUrl The service base URL
    * @param {string} ks The ks
-   * @param {string} entryId The entry ID
    * @returns {RequestBuilder} The request builder
    * @static
    */
-  static getPlaybackContext(serviceUrl: string, ks: string, entryId: string): RequestBuilder {
+  static getPlaybackContext(serviceUrl: string, ks: string): RequestBuilder {
     const headers: Map<string, string> = new Map();
+    const baseEntryServiceEntryId = ks === '{1:result:ks}' ? '{2:result:objects:0:id}' : '{1:result:objects:0:id}';
     headers.set('Content-Type', 'application/json');
     const request = new RequestBuilder(headers);
     request.service = SERVICE_NAME;
@@ -25,7 +25,7 @@ export default class OVPBaseEntryService extends OVPService {
     request.url = request.getUrl(serviceUrl);
     request.tag = 'baseEntry-getPlaybackContext';
     const contextDataParams = {objectType: 'KalturaContextDataParams', flavorTags: 'all'};
-    request.params = {entryId: entryId, ks: ks, contextDataParams: contextDataParams};
+    request.params = {entryId: baseEntryServiceEntryId, ks: ks, contextDataParams: contextDataParams};
     return request;
   }
 

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -486,26 +486,7 @@ describe('getPlaybackContext', () => {
     MultiRequestBuilder.prototype.execute.restore();
   });
 
-  it('should entryId be equal to the requested entryId', done => {
-    sandbox = sinon.sandbox.create();
-    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
-      return new Promise(resolve => {
-        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfWithDrmData.response)});
-      });
-    });
-    provider = new OVPProvider({partnerId: partnerId}, playerVersion);
-    provider
-      .getMediaConfig({entryId: '1_rwbj3j0a', ks: ks})
-      .then(mediaConfig => {
-        mediaConfig.sources.id.should.equal('1_rwbj3j0a');
-        done();
-      })
-      .catch(err => {
-        done(err);
-      });
-  });
-
-  it('should return token with KS for getPlaybackContext', done => {
+  it('should entryId token with KS equal to {1:result:objects:0:id} in getPlaybackContext request', done => {
     sandbox = sinon.sandbox.create();
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
       return new Promise(resolve => {
@@ -527,7 +508,7 @@ describe('getPlaybackContext', () => {
       });
   });
 
-  it('should return token without KS for getPlaybackContext', done => {
+  it('should entryId token without KS equal to {2:result:objects:0:id} in getPlaybackContext request', done => {
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfNoDrmData.response)});

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -474,6 +474,81 @@ describe('getEntryListConfig', function() {
   });
 });
 
+describe('getPlaybackContext', () => {
+  let provider, sandbox;
+  const partnerId = 1068292;
+  const ks =
+    'NTAwZjViZWZjY2NjNTRkNGEyMjU1MTg4OGE1NmUwNDljZWJkMzk1MXwxMDY4MjkyOzEwNjgyOTI7MTQ5MDE3NjE0NjswOzE0OTAwODk3NDYuMDIyNjswO3ZpZXc6Kix3aWRnZXQ6MTs7';
+  const playerVersion = '1.2.3';
+
+  afterEach(() => {
+    sandbox.restore();
+    MultiRequestBuilder.prototype.execute.restore();
+  });
+
+  it('should entryId be equal to the requested entryId', done => {
+    sandbox = sinon.sandbox.create();
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfWithDrmData.response)});
+      });
+    });
+    provider = new OVPProvider({partnerId: partnerId}, playerVersion);
+    provider
+      .getMediaConfig({entryId: '1_rwbj3j0a', ks: ks})
+      .then(mediaConfig => {
+        mediaConfig.sources.id.should.equal('1_rwbj3j0a');
+        done();
+      })
+      .catch(err => {
+        done(err);
+      });
+  });
+
+  it('should return token with KS for getPlaybackContext', done => {
+    sandbox = sinon.sandbox.create();
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfWithDrmData.response)});
+      });
+    });
+    provider = new OVPProvider({partnerId: partnerId}, playerVersion);
+    provider
+      .getMediaConfig({entryId: '1_rwbj3j0a', ks: ks})
+      .then(() => {
+        const getPlaybackContext = provider._dataLoader._multiRequest.requests.find(request => {
+          return request.action === 'getPlaybackContext';
+        });
+        getPlaybackContext.params.entryId.should.equal('{1:result:objects:0:id}');
+        done();
+      })
+      .catch(err => {
+        done(err);
+      });
+  });
+
+  it('should return token without KS for getPlaybackContext', done => {
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfNoDrmData.response)});
+      });
+    });
+    provider = new OVPProvider({partnerId: 1082342}, playerVersion);
+    provider
+      .getMediaConfig({entryId: '1_rsrdfext'})
+      .then(() => {
+        const getPlaybackContext = provider._dataLoader._multiRequest.requests.find(request => {
+          return request.action === 'getPlaybackContext';
+        });
+        getPlaybackContext.params.entryId.should.equal('{2:result:objects:0:id}');
+        done();
+      })
+      .catch(err => {
+        done(err);
+      });
+  });
+});
+
 describe('logger', () => {
   const partnerId = 1068292;
   const playerVersion = '1.2.3';

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -486,7 +486,7 @@ describe('getPlaybackContext', () => {
     MultiRequestBuilder.prototype.execute.restore();
   });
 
-  it('should entryId token with KS equal to {1:result:objects:0:id} in getPlaybackContext request', done => {
+  it('should request entryId token {1:result:objects:0:id} in request with valid KS', done => {
     sandbox = sinon.sandbox.create();
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
       return new Promise(resolve => {
@@ -508,7 +508,7 @@ describe('getPlaybackContext', () => {
       });
   });
 
-  it('should entryId token without KS equal to {2:result:objects:0:id} in getPlaybackContext request', done => {
+  it('should request entryId token {2:result:objects:0:id} in request with anonymous KS', done => {
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function() {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfNoDrmData.response)});


### PR DESCRIPTION
### Description of the Changes

support for redirectFromEntryId means when live is not available, provider will get the VOD entryId instead LIVE entryId.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
