### PR TITLE
fix(FEC-9304): OTT provider doesn't implement getPlaylistConfig api

### DIFF
--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -79,6 +79,15 @@ export default class BaseProvider<MI> {
     );
   }
 
+  // eslint-disable-next-line no-unused-vars
+  getEntryListConfig(entryListInfo: ProviderEntryListObject): Promise<ProviderPlaylistObject> {
+    return Promise.reject(
+      new Error(Error.Severity.CRITICAL, Error.Category.PROVIDER, Error.Code.METHOD_NOT_IMPLEMENTED, {
+        message: 'The provider does not support loading entry list'
+      })
+    );
+  }
+
   _verifyHasSources(sources: ProviderMediaConfigSourcesObject) {
     if (sources.hls.concat(sources.dash, sources.progressive).length === 0) {
       throw new Error(Error.Severity.CRITICAL, Error.Category.SERVICE, Error.Code.MISSING_PLAY_SOURCE, {

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -63,12 +63,20 @@ export default class BaseProvider<MI> {
 
   // eslint-disable-next-line no-unused-vars
   getMediaConfig(mediaInfo: MI): Promise<ProviderMediaConfigObject> {
-    throw new TypeError(`getMediaConfig method must be implement by the derived class`);
+    return Promise.reject(
+      new Error(Error.Severity.CRITICAL, Error.Category.PROVIDER, Error.Code.METHOD_NOT_IMPLEMENTED, {
+        message: 'getMediaConfig method must be implement by the derived class'
+      })
+    );
   }
 
   // eslint-disable-next-line no-unused-vars
-  _parseDataFromResponse(data: Map<string, Function>, ...params: any): ProviderMediaConfigObject {
-    throw new TypeError(`_parseDataFromResponse method must be implement by the derived class`);
+  getPlaylistConfig(playlistInfo: ProviderPlaylistInfoObject): Promise<ProviderPlaylistObject> {
+    return Promise.reject(
+      new Error(Error.Severity.CRITICAL, Error.Category.PROVIDER, Error.Code.METHOD_NOT_IMPLEMENTED, {
+        message: 'The provider does not support loading playlist by id'
+      })
+    );
   }
 
   _verifyHasSources(sources: ProviderMediaConfigSourcesObject) {

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -129,18 +129,6 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
   }
 
   /**
-   * Gets the backend playlist config.
-   * @returns {Promise<Error>} - Not implemented method
-   */
-  getPlaylistConfig(): Promise<Error> {
-    return Promise.reject(
-      new Error(Error.Severity.CRITICAL, Error.Category.PROVIDER, Error.Code.METHOD_NOT_IMPLEMENTED, {
-        message: 'OTT player does not support loading playlist by id'
-      })
-    );
-  }
-
-  /**
    * Gets playlist config from entry list.
    * @param {ProviderEntryListObject} entryListInfo - ott entry list info
    * @returns {Promise<ProviderPlaylistObject>} - The provider playlist config

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -129,6 +129,18 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
   }
 
   /**
+   * Gets the backend playlist config.
+   * @returns {Promise<Error>} - Not implemented method
+   */
+  getPlaylistConfig(): Promise<Error> {
+    return Promise.reject(
+      new Error(Error.Severity.CRITICAL, Error.Category.PROVIDER, Error.Code.METHOD_NOT_IMPLEMENTED, {
+        message: 'OTT player does not support loading playlist by id'
+      })
+    );
+  }
+
+  /**
    * Gets playlist config from entry list.
    * @param {ProviderEntryListObject} entryListInfo - ott entry list info
    * @returns {Promise<ProviderPlaylistObject>} - The provider playlist config

--- a/src/util/error/code.js
+++ b/src/util/error/code.js
@@ -54,14 +54,19 @@ const Code: CodeType = {
   BLOCK_ACTION: 2001,
 
   /**
-   * The server responded with a block action
+   * The provider is missing mandatory parameter/s
    */
   MISSING_MANDATORY_PARAMS: 3000,
 
   /**
    * The server responded with empty sources objects (for HLS, Dash and progressive)
    */
-  MISSING_PLAY_SOURCE: 3001
+  MISSING_PLAY_SOURCE: 3001,
+
+  /**
+   * The provider doesn't implement the called api
+   */
+  METHOD_NOT_IMPLEMENTED: 3002
 };
 
 export {Code};


### PR DESCRIPTION
### Description of the Changes

* Implement `getPlaylistConfig`and `getEntryListConfig` in base provider which rejects with logical error
* fix `getMediaConfig` in base provider to rejects and not to throws as nobody catches the thrown 
* delete `_parseDataFromResponse` from base provider as it not needed (private)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
