### PR TITLE
fix(FEC-10023): use serviceUrl instead of cdnUrl to create playback urls in V7

### DIFF
--- a/src/k-provider/ovp/play-source-url-builder.js
+++ b/src/k-provider/ovp/play-source-url-builder.js
@@ -22,16 +22,16 @@ export default class PlaySourceUrlBuilder {
    */
   static build(urlParams: urlParamsType): string {
     const config = OVPConfiguration.get();
-    const cdnUrl: string = config.cdnUrl;
+    const serviceUrlOrigin: string = new URL(config.serviceUrl).origin;
     const {partnerId, entryId, ks, uiConfId, format, protocol, extension, flavorIds} = urlParams;
 
     //verify mandatory params
-    if (!cdnUrl || !partnerId || !entryId || !format || !protocol) {
+    if (!serviceUrlOrigin || !partnerId || !entryId || !format || !protocol) {
       return '';
     }
 
-    let playUrl = cdnUrl;
-    if (!cdnUrl.endsWith('/')) {
+    let playUrl = serviceUrlOrigin;
+    if (!serviceUrlOrigin.endsWith('/')) {
       playUrl += '/';
     }
     playUrl += 'p/' + partnerId + '/sp/' + partnerId + '00' + '/playManifest/entryId/' + entryId + '/protocol/' + protocol + '/format/' + format;

--- a/src/k-provider/ovp/play-source-url-builder.js
+++ b/src/k-provider/ovp/play-source-url-builder.js
@@ -22,7 +22,7 @@ export default class PlaySourceUrlBuilder {
    */
   static build(urlParams: urlParamsType): string {
     const config = OVPConfiguration.get();
-    const serviceUrlOrigin: string = new URL(config.serviceUrl).origin;
+    const serviceUrlOrigin: string = config.serviceUrl.substr(0, config.serviceUrl.lastIndexOf('/'));
     const {partnerId, entryId, ks, uiConfId, format, protocol, extension, flavorIds} = urlParams;
 
     //verify mandatory params


### PR DESCRIPTION
### Description of the Changes

OVP provider builds the play source manually. Till now it used the CDN Url as the domain for the playbacks. This works but is not correct. 
Changed the url to use serviceUrl (and needed to remove the api_v3)

OTT provider uses urls from server response.

solves FEC-10023

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
