### PR TITLE
build: create canary build on changes on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ jobs:
       name: 'Release'
       script:
         - conventional-github-releaser -p angular -t $GH_TOKEN
+    - stage: Release canary
+      if: (branch = master) AND (type != pull_request) AND commit_message !~ /^chore\(release\)/ AND commit_message !~ /^(chore).*(update dist)$/
+      name: 'Release canary'
+      script:
+        - git checkout master
+        - yarn install
+        - yarn run build
+        - git push https://$GH_TOKEN@github.com/kaltura/playkit-js-providers "master" > /dev/null 2>&1
     # Required tests
     - stage: Tests
       if: (branch = master) OR (tag IS present) OR (type = pull_request)


### PR DESCRIPTION
### Description of the Changes

Issue: providers repo doesn't have a canary build.
Solution: add build for every change on the master branch as we do on the Kaltura player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
