### PR TITLE
feat(FEC-9197): add streamerType and urlType into the getPlaybackContext

### DIFF
--- a/flow-typed/types/media-info.js
+++ b/flow-typed/types/media-info.js
@@ -9,6 +9,8 @@ declare type OTTProviderMediaInfoObject = OVPProviderMediaInfoObject & {
   contextType: string,
   protocol?: string,
   fileIds?: string,
+  streamerType?: string,
+  urlType?: string,
   assetReferenceType?: string,
   formats?: Array<string>
 };

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -47,11 +47,17 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
         const contextType = mediaInfo.contextType || KalturaPlaybackContext.Type.PLAYBACK;
         const mediaType = mediaInfo.mediaType || KalturaAsset.Type.MEDIA;
         const assetReferenceType = mediaInfo.assetReferenceType || KalturaAsset.AssetReferenceType.MEDIA;
-        const playbackContext = {
+        const playbackContext: Object = {
           mediaProtocol: mediaInfo.protocol,
           assetFileIds: mediaInfo.fileIds,
           context: contextType
         };
+        if (mediaInfo.streamerType) {
+          playbackContext.streamerType = mediaInfo.streamerType;
+        }
+        if (mediaInfo.streamerType) {
+          playbackContext.urlType = mediaInfo.urlType;
+        }
         this._dataLoader.add(OTTAssetLoader, {
           entryId: entryId,
           ks: ks,


### PR DESCRIPTION
### Description of the Changes

pass `mediaInfo.streamerType` and `mediaInfo.urlType` on the PlaybackContext object

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
