### PR TITLE
fix(FEC-10722): add KS to external captions

### DIFF
--- a/src/k-provider/ovp/external-captions-builder.js
+++ b/src/k-provider/ovp/external-captions-builder.js
@@ -1,6 +1,6 @@
 // @flow
 
-import OVPProviderParser from './provider-parser';
+import {addKsToUrl} from './provider-parser';
 
 const KalturaCaptionType: CaptionType = {
   SRT: '1',
@@ -23,7 +23,7 @@ class ExternalCaptionsBuilder {
         url = caption.webVttUrl;
         type = CaptionsFormatsMap[KalturaCaptionType.WEBVTT];
       }
-      url = OVPProviderParser.addKsToUrl(url, ks);
+      url = addKsToUrl(url, ks);
       return {
         default: !!caption.isDefault,
         type: type,

--- a/src/k-provider/ovp/external-captions-builder.js
+++ b/src/k-provider/ovp/external-captions-builder.js
@@ -1,5 +1,7 @@
 // @flow
 
+import OVPProviderParser from './provider-parser';
+
 const KalturaCaptionType: CaptionType = {
   SRT: '1',
   DFXP: '2',
@@ -21,8 +23,7 @@ class ExternalCaptionsBuilder {
         url = caption.webVttUrl;
         type = CaptionsFormatsMap[KalturaCaptionType.WEBVTT];
       }
-      const ksParam = url.indexOf('?') === -1 ? '/ks/' : '&ks=';
-      url = ks ? url + ksParam + ks : url;
+      url = OVPProviderParser.addKsToUrl(url, ks);
       return {
         default: !!caption.isDefault,
         type: type,

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -61,15 +61,18 @@ export default class OVPProviderParser {
    * @public
    */
   static addKsToUrl(url: string, ks: string): string {
-    let urlWithKs = url;
+    const hasUrlExtension = path => {
+      const pathName = new URL(path).pathname;
+      return pathName.replace(/^.*[\\/]/, '').indexOf('.') !== -1;
+    };
+    let ksParam;
     if (ks) {
-      if (urlWithKs.indexOf('?') === -1) {
-        const finishWithSlash = urlWithKs.lastIndexOf('/') === urlWithKs.length - 1;
-        urlWithKs = finishWithSlash ? urlWithKs + 'ks/' + ks : urlWithKs + '?ks=' + ks;
+      if (hasUrlExtension(url)) {
+        ksParam = url.indexOf('?') === -1 ? '?ks=' : '&ks=';
       } else {
-        urlWithKs = urlWithKs + '&ks=' + ks;
+        ksParam = '/ks/';
       }
-      return urlWithKs;
+      return url + ksParam + ks;
     }
     return url;
   }

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -52,6 +52,29 @@ export default class OVPProviderParser {
   }
 
   /**
+   * Returns the url with KS
+   * @function addKsToUrl
+   * @param {String} url - The url to add the KS
+   * @param {string} ks - The ks
+   * @returns {string} - The url with KS
+   * @static
+   * @public
+   */
+  static addKsToUrl(url: string, ks: string): string {
+    let urlWithKs = url;
+    if (ks) {
+      if (urlWithKs.indexOf('?') === -1) {
+        const finishWithSlash = urlWithKs.lastIndexOf('/') === urlWithKs.length - 1;
+        urlWithKs = finishWithSlash ? urlWithKs + 'ks/' + ks : urlWithKs + '?ks=' + ks;
+      } else {
+        urlWithKs = urlWithKs + '&ks=' + ks;
+      }
+      return urlWithKs;
+    }
+    return url;
+  }
+
+  /**
    * Returns parsed playlist by given OVP response objects
    * @function getPlaylist
    * @param {any} playlistResponse - The playlist response
@@ -268,15 +291,7 @@ export default class OVPProviderParser {
           protocol
         });
       } else {
-        playUrl = kalturaSource.url;
-        if (ks) {
-          if (playUrl.indexOf('?') === -1) {
-            const lastSlash = playUrl.lastIndexOf('/');
-            playUrl = playUrl.substr(0, lastSlash) + '/ks/' + ks + playUrl.substr(lastSlash, playUrl.length);
-          } else {
-            playUrl = playUrl + '&ks=' + ks;
-          }
-        }
+        playUrl = OVPProviderParser.addKsToUrl(kalturaSource.url, ks);
       }
       if (!playUrl) {
         const message = `failed to create play url from source, discarding source: (${entryId}_${deliveryProfileId}), ${format}`;

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -22,7 +22,7 @@ import KalturaAccessControlMessage from '../common/response-types/kaltura-access
 import type {OVPMediaEntryLoaderResponse} from './loaders/media-entry-loader';
 import {ExternalCaptionsBuilder} from './external-captions-builder';
 
-export default class OVPProviderParser {
+class OVPProviderParser {
   static _logger = getLogger('OVPProviderParser');
 
   /**
@@ -457,3 +457,6 @@ export default class OVPProviderParser {
     return playUrl;
   }
 }
+
+export const addKsToUrl = OVPProviderParser.addKsToUrl;
+export default OVPProviderParser;

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -2926,7 +2926,8 @@ const EntryWithBumperWithKs = {
           language: 'English',
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt',
-          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2',
+          url:
+            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.vtt',
           languageCode: 'en',
           objectType: 'KalturaCaptionPlaybackPluginData'
         },
@@ -2937,7 +2938,7 @@ const EntryWithBumperWithKs = {
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc',
           url:
-            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/?testParam=abc',
+            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.vtt?testParam=abc',
           languageCode: 'es',
           objectType: 'KalturaCaptionPlaybackPluginData'
         }
@@ -3410,7 +3411,7 @@ const EntryWithBumperWitNoSources = {
           language: 'Spanish',
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt',
-          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2',
+          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/',
           languageCode: 'es',
           objectType: 'KalturaCaptionPlaybackPluginData'
         }

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -2922,23 +2922,21 @@ const EntryWithBumperWithKs = {
       playbackCaptions: [
         {
           label: 'En',
-          format: '1',
+          format: '4',
           language: 'English',
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt',
-          url:
-            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.srt',
+          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2',
           languageCode: 'en',
           objectType: 'KalturaCaptionPlaybackPluginData'
         },
         {
           label: 'Esp',
-          format: '1',
+          format: '2',
           language: 'Spanish',
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc',
-          url:
-            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.srt?testParam=abc',
+          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2',
           languageCode: 'es',
           objectType: 'KalturaCaptionPlaybackPluginData'
         }

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -2927,7 +2927,7 @@ const EntryWithBumperWithKs = {
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt',
           url:
-            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.vtt',
+            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.srt',
           languageCode: 'en',
           objectType: 'KalturaCaptionPlaybackPluginData'
         },
@@ -2938,7 +2938,7 @@ const EntryWithBumperWithKs = {
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc',
           url:
-            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.vtt?testParam=abc',
+            'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.srt?testParam=abc',
           languageCode: 'es',
           objectType: 'KalturaCaptionPlaybackPluginData'
         }
@@ -3411,7 +3411,7 @@ const EntryWithBumperWitNoSources = {
           language: 'Spanish',
           webVttUrl:
             'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt',
-          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/',
+          url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2',
           languageCode: 'es',
           objectType: 'KalturaCaptionPlaybackPluginData'
         }

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -1106,7 +1106,7 @@ const EntryWithBumperWithKs = {
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.vtt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       },
       {
         default: false,
@@ -1114,7 +1114,7 @@ const EntryWithBumperWithKs = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       }
     ]
   },
@@ -1223,7 +1223,7 @@ const EntryWithNoBumper = {
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       },
       {
         default: false,

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -1106,7 +1106,7 @@ const EntryWithBumperWithKs = {
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.vtt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.srt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       },
       {
         default: false,
@@ -1114,7 +1114,7 @@ const EntryWithBumperWithKs = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.srt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       }
     ]
   },
@@ -1223,7 +1223,7 @@ const EntryWithNoBumper = {
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       },
       {
         default: false,

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -1102,19 +1102,19 @@ const EntryWithBumperWithKs = {
     captions: [
       {
         default: false,
-        type: 'srt',
+        type: 'vtt',
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/captions.srt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       },
       {
         default: false,
-        type: 'srt',
+        type: 'vtt',
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/captions.srt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       }
     ]
   },

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -755,7 +755,7 @@ describe('getPlaybackContext', () => {
       mediaConfig => {
         try {
           const result = mediaConfig.sources.dash.filter(source => {
-            const ksParam = source.url.indexOf('?') === -1 ? '/ks/' : '&ks=';
+            const ksParam = source.url.indexOf('?') === -1 ? 'ks/' : source.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
             return source.url.indexOf(ksParam + ks) !== -1;
           });
           result.should.deep.equal(mediaConfig.sources.dash);
@@ -782,7 +782,7 @@ describe('getPlaybackContext', () => {
       mediaConfig => {
         try {
           const result = mediaConfig.sources.captions.filter(caption => {
-            const ksParam = caption.url.indexOf('?') === -1 ? '/ks/' : '&ks=';
+            const ksParam = caption.url.indexOf('?') === -1 ? 'ks/' : caption.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
             return caption.url.indexOf(ksParam + ks) !== -1;
           });
           result.should.deep.equal(mediaConfig.sources.captions);
@@ -830,7 +830,8 @@ describe('getPlaybackContext', () => {
       mediaConfig => {
         try {
           const result = mediaConfig.sources.captions.filter(caption => {
-            return caption.url.indexOf('/ks/' + ks) === -1;
+            const ksParam = caption.url.indexOf('?') === -1 ? 'ks/' : caption.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
+            return caption.url.indexOf(ksParam + ks) === -1;
           });
           result.should.deep.equal(mediaConfig.sources.captions);
           done();


### PR DESCRIPTION
### Description of the Changes

issue: ks didn't add in the correct place.
solution: set the ks as a parameter on the end of URL and if the URL ended with / add the ks with slashes

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
