### PR TITLE
fix(FEC-10699): objectType KalturaLiveAsset should check enableTrickPlay for dvr before externalIds

### DIFF
--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -22,10 +22,10 @@ const MediaTypeCombinations: {[mediaType: string]: Object} = {
   [KalturaAsset.Type.MEDIA]: {
     [KalturaPlaybackContext.Type.TRAILER]: () => ({type: MediaEntry.Type.VOD}),
     [KalturaPlaybackContext.Type.PLAYBACK]: mediaAssetData => {
-      if (parseInt(mediaAssetData.externalIds) > 0) {
-        return {type: MediaEntry.Type.LIVE, dvrStatus: MediaEntry.DvrStatus.OFF};
-      } else if (mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
+      if (mediaAssetData.objectType === LIVE_ASST_OBJECT_TYPE) {
         return {type: MediaEntry.Type.LIVE, dvrStatus: mediaAssetData.enableTrickPlay ? MediaEntry.DvrStatus.ON : MediaEntry.DvrStatus.OFF};
+      } else if (parseInt(mediaAssetData.externalIds) > 0) {
+        return {type: MediaEntry.Type.LIVE, dvrStatus: MediaEntry.DvrStatus.OFF};
       }
       return {type: MediaEntry.Type.VOD};
     }

--- a/test/src/k-provider/ott/provider-parser.spec.js
+++ b/test/src/k-provider/ott/provider-parser.spec.js
@@ -3,13 +3,13 @@ import {MediaLiveAssetData} from './be-data';
 
 describe('provider parser', function () {
   describe('_getMediaType', () => {
-    it('should check KalturaLiveAsset with externalIds returns live with dvr false', done => {
+    it('should check KalturaLiveAsset with enableTrickPlay true and externalIds > 0 returns live with dvr', done => {
       const typeData = OTTProviderParser._getMediaType(MediaLiveAssetData, 'media', 'PLAYBACK');
       typeData.type.should.equal('Live');
-      typeData.dvrStatus.should.equal(0);
+      typeData.dvrStatus.should.equal(1);
       done();
     });
-    it('should check KalturaLiveAsset with trickPlay false returns live with dvr false', done => {
+    it('should check KalturaLiveAsset with enableTrickPlay false returns live with dvr false', done => {
       const MediaLiveAssetDataCopy = JSON.parse(JSON.stringify(MediaLiveAssetData));
       MediaLiveAssetDataCopy.externalIds = 0;
       MediaLiveAssetDataCopy.enableTrickPlay = false;
@@ -18,7 +18,7 @@ describe('provider parser', function () {
       typeData.dvrStatus.should.equal(0);
       done();
     });
-    it('should check KalturaLiveAsset with trickPlay true returns live with dvr true', done => {
+    it('should check KalturaLiveAsset with enableTrickPlay true returns live with dvr true', done => {
       const MediaLiveAssetDataCopy = JSON.parse(JSON.stringify(MediaLiveAssetData));
       MediaLiveAssetDataCopy.externalIds = 0;
       const typeData = OTTProviderParser._getMediaType(MediaLiveAssetDataCopy, 'media', 'PLAYBACK');


### PR DESCRIPTION
### Description of the Changes

I switched the if else order to give precedence to KalturaLiveAsset enableTrickPlay
Updated tests accordingly 

solves FEC-10699

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
