### PR TITLE
fix(FEC-11104): Crash on IE11 URL doesn't exist

### DIFF
--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -62,8 +62,9 @@ class OVPProviderParser {
    */
   static addKsToUrl(url: string, ks: string): string {
     const hasUrlExtension = path => {
-      const pathName = new URL(path).pathname;
-      return pathName.replace(/^.*[\\/]/, '').indexOf('.') !== -1;
+      const pathWithoutQuery = path.split('?')[0];
+      const pathAfterLastSlash = pathWithoutQuery.replace(/^.*[\\/]/, '');
+      return pathAfterLastSlash.indexOf('.') !== -1;
     };
     let ksParam;
     if (ks) {


### PR DESCRIPTION
### Description of the Changes

Issue: Crash on IE11 URL object doesn't exist.
Solution: check the extension without the URL object.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
