### PR TITLE
fix(FEC-11363): OTT player doesn't get error for invalid KS

### DIFF
--- a/src/k-provider/common/multi-request-builder.js
+++ b/src/k-provider/common/multi-request-builder.js
@@ -89,7 +89,7 @@ export class MultiRequestResult {
    */
   constructor(response: Object) {
     this.success = true;
-    const responseArr = response.result ? response.result : response;
+    const responseArr = response.result ? (Array.isArray(response.result) ? response.result : [response.result]) : response;
     responseArr.forEach(result => {
       const serviceResult: ServiceResult = new ServiceResult(result);
       this.results.push(serviceResult);

--- a/src/k-provider/common/multi-request-builder.js
+++ b/src/k-provider/common/multi-request-builder.js
@@ -89,7 +89,8 @@ export class MultiRequestResult {
    */
   constructor(response: Object) {
     this.success = true;
-    const responseArr = response.result ? (Array.isArray(response.result) ? response.result : [response.result]) : response;
+    const result = response.result ? response.result : response;
+    const responseArr = Array.isArray(result) ? result : [result];
     responseArr.forEach(result => {
       const serviceResult: ServiceResult = new ServiceResult(result);
       this.results.push(serviceResult);

--- a/test/src/k-provider/ott/be-data.js
+++ b/test/src/k-provider/ott/be-data.js
@@ -1207,6 +1207,19 @@ const BlockActionEntry = {
   }
 };
 
+const InvalidKSFormat = {
+  response: {
+    executionTime: 0.0003546,
+    result: {
+      error: {
+        code: '500015',
+        message: 'Invalid KS format',
+        objectType: 'KalturaAPIException'
+      }
+    }
+  }
+};
+
 const PlaylistByEntryList = {
   response: {
     result: [
@@ -3283,6 +3296,7 @@ export {
   AnonymousEntryWithoutUIConfWithDrmData,
   LiveEntryNoDrmData,
   BlockActionEntry,
+  InvalidKSFormat,
   PlaylistByEntryList,
   AnonymousPlaylistByEntryList,
   EntryWithBumper,

--- a/test/src/k-provider/ott/be-data.js
+++ b/test/src/k-provider/ott/be-data.js
@@ -1209,7 +1209,6 @@ const BlockActionEntry = {
 
 const InvalidKSFormat = {
   response: {
-    executionTime: 0.0003546,
     result: {
       error: {
         code: '500015',


### PR DESCRIPTION
### Description of the Changes

OTT invalid KS error is coming as object not as array so need to wrap it by array

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
