### PR TITLE
feat(FEC-11399): allow ignoring server config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,8 @@ var provider = new playkit.providers.ott.Provider(config);
   uiConfId: number, // optional
   env: ProviderEnvConfigObject, // optional
   networkRetryParameters: ProviderNetworkRetryParameters, // optional
-  filterOptions: ProviderFilterOptionsObject // optional
+  filterOptions: ProviderFilterOptionsObject, // optional
+  ignoreServerConfig: boolean // optional
 }
 ```
 
@@ -192,3 +193,12 @@ var provider = new playkit.providers.ott.Provider(config);
 > ```
 >
 > ##### Description: Defines whether after a livestream ends there should be a redirect to the VOD entry or not.
+
+> ##
+>
+> ### config.ignoreServerConfig
+>
+> ##### Type: `boolean`
+>
+>
+> ##### Description: Instructs the player to ignore the server configuration.

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -9,5 +9,6 @@ declare type ProviderOptionsObject = {
   uiConfId?: number,
   env?: ProviderEnvConfigObject,
   networkRetryParameters?: ProviderNetworkRetryParameters,
-  filterOptions?: ProviderFilterOptionsObject
+  filterOptions?: ProviderFilterOptionsObject,
+  ignoreServerConfig?: boolean
 };


### PR DESCRIPTION
### Description of the Changes

Add flag to provider configuration to allow ignoring server config.
Related PRs:

- https://github.com/kaltura/kaltura-player-js/pull/480
- https://github.com/kaltura/playkit-js-dual-screen/pull/29

Fixes FEC-11399.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
