### PR TITLE
feat(FEC-11611): [Web] Pass the program ID when sending a bookmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 language: node_js
 node_js:
   - 'node'
+env:
+  global:
+    - NODE_OPTIONS="--openssl-legacy-provider"
 
 addons:
   chrome: stable

--- a/flow-typed/types/media-config-metadata.js
+++ b/flow-typed/types/media-config-metadata.js
@@ -1,5 +1,6 @@
 // @flow
 declare type ProviderMediaConfigMetadataObject = {
   name: string,
-  description: string
+  description: string,
+  epgId?: string
 };

--- a/flow-typed/types/media-config-metadata.js
+++ b/flow-typed/types/media-config-metadata.js
@@ -2,5 +2,9 @@
 declare type ProviderMediaConfigMetadataObject = {
   name: string,
   description: string,
-  epgId?: string
+  mediaType: string,
+  metas: Object,
+  tags: Object,
+  epgId?: string,
+  recordingId?: string
 };

--- a/flow-typed/types/media-config-metadata.js
+++ b/flow-typed/types/media-config-metadata.js
@@ -4,7 +4,7 @@ declare type ProviderMediaConfigMetadataObject = {
   description?: string,
   mediaType?: string,
   metas?: Object,
-  tags: Object,
+  tags?: Object,
   epgId?: string,
   recordingId?: string
 };

--- a/flow-typed/types/media-config-metadata.js
+++ b/flow-typed/types/media-config-metadata.js
@@ -1,9 +1,9 @@
 // @flow
 declare type ProviderMediaConfigMetadataObject = {
   name: string,
-  description: string,
-  mediaType: string,
-  metas: Object,
+  description?: string,
+  mediaType?: string,
+  metas?: Object,
   tags: Object,
   epgId?: string,
   recordingId?: string

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -114,7 +114,7 @@ export default class OTTProviderParser {
     metaData.description = mediaAsset.description;
     metaData.name = mediaAsset.name;
     if (mediaAsset.data.epgId) metaData.epgId = mediaAsset.data.epgId;
-    if (mediaAsset.data.recordingId) metaData.epgId = mediaAsset.data.recordingId;
+    if (mediaAsset.data.recordingId) metaData.recordingId = mediaAsset.data.recordingId;
     if (requestData && requestData.mediaType) metaData.mediaType = requestData.mediaType;
     mediaEntry.metadata = metaData;
     mediaEntry.poster = OTTProviderParser._getPoster(mediaAsset.pictures);

--- a/src/k-provider/ott/provider-parser.js
+++ b/src/k-provider/ott/provider-parser.js
@@ -113,6 +113,8 @@ export default class OTTProviderParser {
     const metaData = OTTProviderParser.reconstructMetadata(mediaAsset);
     metaData.description = mediaAsset.description;
     metaData.name = mediaAsset.name;
+    if (mediaAsset.data.epgId) metaData.epgId = mediaAsset.data.epgId;
+    if (mediaAsset.data.recordingId) metaData.epgId = mediaAsset.data.recordingId;
     if (requestData && requestData.mediaType) metaData.mediaType = requestData.mediaType;
     mediaEntry.metadata = metaData;
     mediaEntry.poster = OTTProviderParser._getPoster(mediaAsset.pictures);

--- a/src/k-provider/ott/services/bookmark/bookmark-service.js
+++ b/src/k-provider/ott/services/bookmark/bookmark-service.js
@@ -2,10 +2,18 @@
 import OTTService from '../ott-service';
 import RequestBuilder from '../../../../util/request-builder';
 import OTTConfiguration from '../../config';
+import getLogger from '../../../../util/logger';
 
 const SERVICE_NAME: string = 'bookmark';
 
 export default class OTTBookmarkService extends OTTService {
+  /**
+   * The BookmarkService logger
+   * @member {OTTBookmarkService} _logger
+   * @private
+   * @static
+   */
+  static _logger: any = getLogger('BookmarkService');
   /**
    * Creates an instance of RequestBuilder for session.startWidgetSession
    * @function add
@@ -39,6 +47,7 @@ export default class OTTBookmarkService extends OTTService {
       playerData: playerData
     };
     if (bookmark.programId) bookmarkServiceParams.programId = bookmark.programId;
+    this._logger.debug('the processed bookmark', bookmarkServiceParams);
     const config = OTTConfiguration.get();
     const serviceParams = config.serviceParams;
     Object.assign(serviceParams, {bookmark: bookmarkServiceParams, ks: ks});

--- a/src/k-provider/ott/services/bookmark/bookmark-service.js
+++ b/src/k-provider/ott/services/bookmark/bookmark-service.js
@@ -38,6 +38,7 @@ export default class OTTBookmarkService extends OTTService {
       position: bookmark.position,
       playerData: playerData
     };
+    if (bookmark.programId) bookmarkServiceParams.programId = bookmark.programId;
     const config = OTTConfiguration.get();
     const serviceParams = config.serviceParams;
     Object.assign(serviceParams, {bookmark: bookmarkServiceParams, ks: ks});

--- a/src/k-provider/ott/services/bookmark/bookmark-service.js
+++ b/src/k-provider/ott/services/bookmark/bookmark-service.js
@@ -47,7 +47,7 @@ export default class OTTBookmarkService extends OTTService {
       playerData: playerData
     };
     if (bookmark.programId) bookmarkServiceParams.programId = bookmark.programId;
-    this._logger.debug('the processed bookmark', bookmarkServiceParams);
+    this._logger.debug('bookmark added', bookmarkServiceParams);
     const config = OTTConfiguration.get();
     const serviceParams = config.serviceParams;
     Object.assign(serviceParams, {bookmark: bookmarkServiceParams, ks: ks});

--- a/test/src/k-provider/ott/be-data.js
+++ b/test/src/k-provider/ott/be-data.js
@@ -502,7 +502,9 @@ const AnonymousEntryWithoutUIConfWithDrmData = {
         enableCatchUp: false,
         enableStartOver: false,
         enableTrickPlay: false,
-        objectType: 'KalturaMediaAsset'
+        objectType: 'KalturaMediaAsset',
+        epgId: '454032895',
+        recordingId: '774036475'
       },
       {
         sources: [
@@ -1114,6 +1116,7 @@ const LiveEntryNoDrmData = {
         },
         startDate: 946684800,
         endDate: 2524608000,
+        epgId: '454032895',
         enableCdvr: true,
         enableCatchUp: true,
         enableStartOver: true,

--- a/test/src/k-provider/ott/media-config-data.js
+++ b/test/src/k-provider/ott/media-config-data.js
@@ -509,7 +509,9 @@ const FilteredSourcesByDeviceType = {
       },
       description:
         "After the Bergens invade Troll Village, Poppy, the happiest Troll ever born, and the curmudgeonly Branch set off on a journey to rescue her friends. DreamWorks Animation's TROLLS is an irreverent comedy extravaganza with incredible music! From the genius creators of SHREK, TROLLS stars Anna Kendrick as Poppy, the optimistic leader of the Trolls, and her polar opposite, Branch, played by Justin Timberlake. Together, this unlikely pair of Trolls must embark on an adventure that takes them far beyond the only world they've ever known."
-    }
+    },
+    epgId: '454032895',
+    recordingId: '774036475'
   }
 };
 
@@ -729,7 +731,8 @@ const LiveEntryNoDrm = {
         QUALITY: 'hd|',
         Source: 'Web3|'
       },
-      description: '***nadya_aes***'
+      description: '***nadya_aes***',
+      epgId: '454032895'
     }
   },
   plugins: {}

--- a/test/src/k-provider/ott/media-config-data.js
+++ b/test/src/k-provider/ott/media-config-data.js
@@ -121,6 +121,8 @@ const NoPluginsWithDrm = {
     metadata: {
       mediaType: mediaTypeConf,
       name: 'Trolls',
+      epgId: '454032895',
+      recordingId: '774036475',
       metas: {
         'App Link': '',
         'Catchup allowed': false,
@@ -485,6 +487,8 @@ const FilteredSourcesByDeviceType = {
     metadata: {
       mediaType: KalturaAsset.Type.RECORDING,
       name: 'Trolls',
+      epgId: '454032895',
+      recordingId: '774036475',
       metas: {
         'App Link': '',
         'Catchup allowed': false,
@@ -509,9 +513,7 @@ const FilteredSourcesByDeviceType = {
       },
       description:
         "After the Bergens invade Troll Village, Poppy, the happiest Troll ever born, and the curmudgeonly Branch set off on a journey to rescue her friends. DreamWorks Animation's TROLLS is an irreverent comedy extravaganza with incredible music! From the genius creators of SHREK, TROLLS stars Anna Kendrick as Poppy, the optimistic leader of the Trolls, and her polar opposite, Branch, played by Justin Timberlake. Together, this unlikely pair of Trolls must embark on an adventure that takes them far beyond the only world they've ever known."
-    },
-    epgId: '454032895',
-    recordingId: '774036475'
+    }
   }
 };
 


### PR DESCRIPTION
### Description of the Changes

save the epgId from provider response 
pass it as program ID parameter when sending a bookmark

related pr: 
https://github.com/kaltura/playkit-js-ott-analytics/pull/64

Solves FEC-11611

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
