### PR TITLE
feat(FEC-11696): add ks paramater in doRequest

### DIFF
--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -7,7 +7,6 @@ export default class BaseProvider<MI> {
   _partnerId: number;
   _widgetId: ?string;
   _ks: string;
-  _anonymousKS: string;
   _uiConfId: ?number;
   _dataLoader: DataLoaderManager;
   _playerVersion: string;
@@ -43,14 +42,6 @@ export default class BaseProvider<MI> {
     this._ks = value;
   }
 
-  get anonymousKS(): string {
-    return this._anonymousKS;
-  }
-
-  set anonymousKS(value: string): void {
-    this._anonymousKS = value;
-  }
-
   get playerVersion(): string {
     return this._playerVersion;
   }
@@ -66,7 +57,6 @@ export default class BaseProvider<MI> {
     this._uiConfId = options.uiConfId;
     this._isAnonymous = !options.ks;
     this._ks = options.ks || '';
-    this._anonymousKS = '';
     this._playerVersion = playerVersion;
   }
 

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -7,6 +7,7 @@ export default class BaseProvider<MI> {
   _partnerId: number;
   _widgetId: ?string;
   _ks: string;
+  _anonymousKs: string;
   _uiConfId: ?number;
   _dataLoader: DataLoaderManager;
   _playerVersion: string;
@@ -42,6 +43,14 @@ export default class BaseProvider<MI> {
     this._ks = value;
   }
 
+  get anonymousKs(): string {
+    return this._anonymousKs;
+  }
+
+  set anonymousKs(value: string): void {
+    this._anonymousKs = value;
+  }
+
   get playerVersion(): string {
     return this._playerVersion;
   }
@@ -57,6 +66,7 @@ export default class BaseProvider<MI> {
     this._uiConfId = options.uiConfId;
     this._isAnonymous = !options.ks;
     this._ks = options.ks || '';
+    this._anonymousKs = '';
     this._playerVersion = playerVersion;
   }
 

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -7,6 +7,7 @@ export default class BaseProvider<MI> {
   _partnerId: number;
   _widgetId: ?string;
   _ks: string;
+  _anonymousKS: string;
   _uiConfId: ?number;
   _dataLoader: DataLoaderManager;
   _playerVersion: string;
@@ -42,6 +43,14 @@ export default class BaseProvider<MI> {
     this._ks = value;
   }
 
+  get anonymousKS(): string {
+    return this._anonymousKS;
+  }
+
+  set anonymousKS(value: string): void {
+    this._anonymousKS = value;
+  }
+
   get playerVersion(): string {
     return this._playerVersion;
   }
@@ -57,6 +66,7 @@ export default class BaseProvider<MI> {
     this._uiConfId = options.uiConfId;
     this._isAnonymous = !options.ks;
     this._ks = options.ks || '';
+    this._anonymousKS = '';
     this._playerVersion = playerVersion;
   }
 

--- a/src/k-provider/common/base-provider.js
+++ b/src/k-provider/common/base-provider.js
@@ -7,7 +7,6 @@ export default class BaseProvider<MI> {
   _partnerId: number;
   _widgetId: ?string;
   _ks: string;
-  _anonymousKs: string;
   _uiConfId: ?number;
   _dataLoader: DataLoaderManager;
   _playerVersion: string;
@@ -43,14 +42,6 @@ export default class BaseProvider<MI> {
     this._ks = value;
   }
 
-  get anonymousKs(): string {
-    return this._anonymousKs;
-  }
-
-  set anonymousKs(value: string): void {
-    this._anonymousKs = value;
-  }
-
   get playerVersion(): string {
     return this._playerVersion;
   }
@@ -66,7 +57,6 @@ export default class BaseProvider<MI> {
     this._uiConfId = options.uiConfId;
     this._isAnonymous = !options.ks;
     this._ks = options.ks || '';
-    this._anonymousKs = '';
     this._playerVersion = playerVersion;
   }
 

--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -54,7 +54,7 @@ export default class DataLoaderManager {
       // Add requests to multiRequest queue
       requests.forEach(request => {
         request.params = request.params || {};
-        request.params.ks = params.ks || ks;
+        request.params.ks = request.params.ks || ks;
         this._multiRequest.add(request);
       });
       // Create range array of current execution_loader requests

--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -39,9 +39,10 @@ export default class DataLoaderManager {
    * @function
    * @param {Function} loader Loader to add
    * @param {Object} params Loader params
+   * @param {string} ks ks
    * @returns {void}
    */
-  add(loader: Function, params: Object): void {
+  add(loader: Function, params: Object, ks?: string): void {
     let execution_loader = new loader(params);
     if (execution_loader.isValid()) {
       this._loaders.set(loader.id, execution_loader);
@@ -53,7 +54,7 @@ export default class DataLoaderManager {
       // Add requests to multiRequest queue
       requests.forEach(request => {
         request.params = request.params || {};
-        request.params.ks = request.params.ks || params.ks;
+        request.params.ks = params.ks || ks;
         this._multiRequest.add(request);
       });
       // Create range array of current execution_loader requests

--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -50,8 +50,10 @@ export default class DataLoaderManager {
       // Get the requests
       let requests = execution_loader.requests;
       this._multiRequest.retryConfig = this._networkRetryConfig;
-      // Add requests to muktiRequest queue
+      // Add requests to multiRequest queue
       requests.forEach(request => {
+        request.params = request.params || {};
+        request.params.ks = request.params.ks || params.ks;
         this._multiRequest.add(request);
       });
       // Create range array of current execution_loader requests

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -121,17 +121,15 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
   _parseKsFromResponse(data: Map<string, Function>): string {
     let ks = '';
-    if (data) {
-      if (data.has(OVPSessionLoader.id)) {
-        const sessionLoader = data.get(OVPSessionLoader.id);
-        if (sessionLoader && sessionLoader.response) {
-          ks = sessionLoader.response;
-          if (this.widgetId !== this.defaultWidgetId) {
-            this.ks = ks;
-            this._isAnonymous = false;
-          } else {
-            this.anonymousKs = ks;
-          }
+    if (data && data.has(OVPSessionLoader.id)) {
+      const sessionLoader = data.get(OVPSessionLoader.id);
+      if (sessionLoader && sessionLoader.response) {
+        ks = sessionLoader.response;
+        if (this.widgetId !== this.defaultWidgetId) {
+          this.ks = ks;
+          this._isAnonymous = false;
+        } else {
+          this.anonymousKs = ks;
         }
       }
     }

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -14,6 +14,7 @@ import Error from '../../util/error/error';
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
+  _anonymousKs: string;
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -25,10 +26,19 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
     this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
+    this._anonymousKs = '';
   }
 
   get env() {
     return OVPConfiguration.get();
+  }
+
+  get anonymousKs(): string {
+    return this._anonymousKs;
+  }
+
+  set anonymousKs(value: string): void {
+    this._anonymousKs = value;
   }
 
   /**

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -166,7 +166,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     }
 
     const ks = this._parseKsFromResponse(data);
-    ks ? (mediaConfig.session.ks = ks) : (mediaConfig.session.ks = this.ks);
+    mediaConfig.session.ks = ks ? ks : this.ks;
 
     if (data) {
       if (data.has(OVPMediaEntryLoader.id)) {
@@ -247,6 +247,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   _parsePlaylistDataFromResponse(data: Map<string, Function>): ProviderPlaylistObject {
     this._logger.debug('Data parsing started');
     const playlistConfig: ProviderPlaylistObject = this._getPlaylistObject();
+    this._parseKsFromResponse(data);
     if (data && data.has(OVPPlaylistLoader.id)) {
       const playlistLoader = data.get(OVPPlaylistLoader.id);
       if (playlistLoader && playlistLoader.response) {
@@ -303,6 +304,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   _parseEntryListDataFromResponse(data: Map<string, Function>): ProviderPlaylistObject {
     this._logger.debug('Data parsing started');
     const playlistConfig: ProviderPlaylistObject = this._getPlaylistObject();
+    this._parseKsFromResponse(data);
     if (data && data.has(OVPEntryListLoader.id)) {
       const playlistLoader = data.get(OVPEntryListLoader.id);
       if (playlistLoader && playlistLoader.response) {

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -76,24 +76,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
   doRequest(loaders: Array<RequestLoader>, externalKS?: string): Promise<any> {
     let ks: string = externalKS || this.ks || this.anonymousKS;
-    if (!ks) {
-      return new Promise((resolve, reject) => {
-        this._doKsRequest().then(returnedKS => {
-          this._doRequest(loaders, returnedKS).then(
-            response => {
-              try {
-                resolve(response);
-              } catch (err) {
-                reject(err);
-              }
-            },
-            err => {
-              reject(err);
-            }
-          );
-        });
-      });
-    } else {
+    const promise = ks ? Promise.resolve() : this._doKsRequest();
+    return promise.then(returnedKs => {
+      if (returnedKs) {
+        ks = returnedKs;
+      }
       return new Promise((resolve, reject) => {
         this._doRequest(loaders, ks).then(
           response => {
@@ -108,7 +95,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
           }
         );
       });
-    }
+    });
   }
 
   _doRequest(loaders: Array<RequestLoader>, ks: string): Promise<any> {

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -76,11 +76,24 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
   doRequest(loaders: Array<RequestLoader>, externalKS?: string): Promise<any> {
     let ks: string = externalKS || this.ks || this.anonymousKS;
-    const promise = ks ? Promise.resolve() : this._doKsRequest();
-    return promise.then(returnedKs => {
-      if (returnedKs) {
-        ks = returnedKs;
-      }
+    if (!ks) {
+      return new Promise((resolve, reject) => {
+        this._doKsRequest().then(returnedKS => {
+          this._doRequest(loaders, returnedKS).then(
+            response => {
+              try {
+                resolve(response);
+              } catch (err) {
+                reject(err);
+              }
+            },
+            err => {
+              reject(err);
+            }
+          );
+        });
+      });
+    } else {
       return new Promise((resolve, reject) => {
         this._doRequest(loaders, ks).then(
           response => {
@@ -95,7 +108,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
           }
         );
       });
-    });
+    }
   }
 
   _doRequest(loaders: Array<RequestLoader>, ks: string): Promise<any> {

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -41,6 +41,10 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     this._anonymousKs = value;
   }
 
+  get userKs(): string {
+    return this.ks || this._anonymousKs;
+  }
+
   /**
    * Gets the backend media config.
    * @param {OVPProviderMediaInfoObject} mediaInfo - ovp media info
@@ -54,12 +58,12 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const entryId = mediaInfo.entryId;
       const referenceId = mediaInfo.referenceId;
       if (entryId || referenceId) {
-        let ks: string = this.ks || this.anonymousKs;
+        let ks: string = this.userKs;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -85,7 +89,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   }
 
   doRequest(loaders: Array<RequestLoader>, ks?: string): Promise<any> {
-    let theKs: string = ks || this.ks || this.anonymousKs;
+    let theKs: string = ks || this.userKs;
     const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, theKs, this._networkRetryConfig);
 
     return new Promise((resolve, reject) => {
@@ -206,11 +210,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const playlistId = playlistInfo.playlistId;
       if (playlistId) {
-        let ks: string = this.ks || this.anonymousKs;
+        let ks: string = this.userKs;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -261,11 +265,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const entries = entryListInfo.entries;
       if (entries && entries.length) {
-        let ks: string = this.ks || this.anonymousKs;
+        let ks: string = this.userKs;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -14,7 +14,6 @@ import Error from '../../util/error/error';
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
-  _anonymousKs: string;
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -26,23 +25,10 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
     this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
-    this._anonymousKs = '';
   }
 
   get env() {
     return OVPConfiguration.get();
-  }
-
-  get anonymousKs(): string {
-    return this._anonymousKs;
-  }
-
-  set anonymousKs(value: string): void {
-    this._anonymousKs = value;
-  }
-
-  get userKs(): string {
-    return this.ks || this._anonymousKs;
   }
 
   /**
@@ -58,12 +44,12 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const entryId = mediaInfo.entryId;
       const referenceId = mediaInfo.referenceId;
       if (entryId || referenceId) {
-        let ks: string = this.userKs;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -89,18 +75,15 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   }
 
   doRequest(loaders: Array<RequestLoader>, ks?: string): Promise<any> {
-    if (ks) {
-      this.ks = ks;
-      this._isAnonymous = false;
-    }
-    const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
+    let theKs: string = ks || this.ks;
+    const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, theKs, this._networkRetryConfig);
 
     return new Promise((resolve, reject) => {
-      if (!this.userKs) {
+      if (!theKs) {
         dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
       }
       loaders.forEach((loaderRequest: RequestLoader) => {
-        if (!this.userKs) loaderRequest.params.ks = '{1:result:ks}';
+        loaderRequest.params.ks = this.ks || '{1:result:ks}';
         dataLoader.add(loaderRequest.loader, loaderRequest.params);
       });
       return dataLoader.fetchData().then(
@@ -128,8 +111,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         if (this.widgetId !== this.defaultWidgetId) {
           this.ks = ks;
           this._isAnonymous = false;
-        } else {
-          this.anonymousKs = ks;
         }
       }
     }
@@ -220,11 +201,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const playlistId = playlistInfo.playlistId;
       if (playlistId) {
-        let ks: string = this.userKs;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -276,11 +257,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.widgetId !== this.defaultWidgetId) {
       this._isAnonymous = false;
     }
-    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.userKs, this._networkRetryConfig);
+    this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
       const entries = entryListInfo.entries;
       if (entries && entries.length) {
-        let ks: string = this.userKs;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -49,7 +49,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
       const entryId = mediaInfo.entryId;
       const referenceId = mediaInfo.referenceId;
       if (entryId || referenceId) {
-        let ks: string = this.ks || this.anonymousKS;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -74,45 +74,8 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     });
   }
 
-  doRequest(loaders: Array<RequestLoader>, externalKS?: string): Promise<any> {
-    let ks: string = externalKS || this.ks || this.anonymousKS;
-    if (!ks) {
-      return new Promise((resolve, reject) => {
-        this._doKsRequest().then(returnedKS => {
-          this._doRequest(loaders, returnedKS).then(
-            response => {
-              try {
-                resolve(response);
-              } catch (err) {
-                reject(err);
-              }
-            },
-            err => {
-              reject(err);
-            }
-          );
-        });
-      });
-    } else {
-      return new Promise((resolve, reject) => {
-        this._doRequest(loaders, ks).then(
-          response => {
-            try {
-              resolve(response);
-            } catch (err) {
-              reject(err);
-            }
-          },
-          err => {
-            reject(err);
-          }
-        );
-      });
-    }
-  }
-
-  _doRequest(loaders: Array<RequestLoader>, ks: string): Promise<any> {
-    const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, ks, this._networkRetryConfig);
+  doRequest(loaders: Array<RequestLoader>): Promise<any> {
+    const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
 
     return new Promise((resolve, reject) => {
       loaders.forEach((loaderRequest: RequestLoader) => {
@@ -132,45 +95,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
       );
     });
   }
-
-  _doKsRequest(): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, '', this._networkRetryConfig);
-      dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
-      return dataLoader.fetchData().then(
-        response => {
-          try {
-            resolve(this._parseKsFromResponse(response));
-          } catch (err) {
-            reject(err);
-          }
-        },
-        err => {
-          reject(err);
-        }
-      );
-    });
-  }
-
-  _parseKsFromResponse(data: Map<string, Function>): string {
-    let ks = '';
-    if (data) {
-      if (data.has(OVPSessionLoader.id)) {
-        const sessionLoader = data.get(OVPSessionLoader.id);
-        if (sessionLoader && sessionLoader.response) {
-          ks = sessionLoader.response;
-          if (this.widgetId !== this.defaultWidgetId) {
-            this.ks = ks;
-            this._isAnonymous = false;
-          } else {
-            this.anonymousKS = ks;
-          }
-        }
-      }
-    }
-    return ks;
-  }
-
   _getEntryRedirectFilter(mediaInfo: Object): boolean {
     return typeof mediaInfo.redirectFromEntryId === 'boolean'
       ? mediaInfo.redirectFromEntryId
@@ -199,11 +123,18 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (this.uiConfId) {
       mediaConfig.session.uiConfId = this.uiConfId;
     }
-
-    const ks = this._parseKsFromResponse(data);
-    ks ? (mediaConfig.session.ks = ks) : (mediaConfig.session.ks = this.ks);
-
     if (data) {
+      if (data.has(OVPSessionLoader.id)) {
+        const sessionLoader = data.get(OVPSessionLoader.id);
+        if (sessionLoader && sessionLoader.response) {
+          mediaConfig.session.ks = sessionLoader.response;
+          if (this.widgetId !== this.defaultWidgetId) {
+            this.ks = mediaConfig.session.ks;
+          }
+        }
+      } else {
+        mediaConfig.session.ks = this.ks;
+      }
       if (data.has(OVPMediaEntryLoader.id)) {
         const mediaLoader = data.get(OVPMediaEntryLoader.id);
         if (mediaLoader && mediaLoader.response) {
@@ -259,7 +190,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     return new Promise((resolve, reject) => {
       const playlistId = playlistInfo.playlistId;
       if (playlistId) {
-        let ks: string = this.ks || this.anonymousKS;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
@@ -314,7 +245,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     return new Promise((resolve, reject) => {
       const entries = entryListInfo.entries;
       if (entries && entries.length) {
-        let ks: string = this.ks || this.anonymousKS;
+        let ks: string = this.ks;
         if (!ks) {
           ks = '{1:result:ks}';
           this._dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -83,8 +83,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         dataLoader.add(OVPSessionLoader, {widgetId: this.widgetId});
       }
       loaders.forEach((loaderRequest: RequestLoader) => {
-        loaderRequest.params.ks = theKs || '{1:result:ks}';
-        dataLoader.add(loaderRequest.loader, loaderRequest.params);
+        dataLoader.add(loaderRequest.loader, loaderRequest.params, theKs || '{1:result:ks}');
       });
       return dataLoader.fetchData().then(
         response => {

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -3644,6 +3644,18 @@ const EntryWithBumperWitNoSources = {
   ]
 };
 
+const Session = {
+  response: [
+    {
+      ks:
+        'NDIxYjc3MmJhMmI1YTBhYTc1N2U2ODI0NjA4MWU0YzVhNGI3ZDQzM3wxMDY4MjkyOzEwNjgyOTI7MTYzOTM5NDk2OTsyOzE2MzkzMDg1NjkuOTg1NTtwaGlsbC5wcmljZUBkaXNuZXkuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs',
+      objectType: 'KalturaStartWidgetSessionResponse',
+      partnerId: 1068292,
+      userId: 0
+    }
+  ]
+};
+
 export {
   AnonymousMocEntryWithoutUIConfNoDrmData,
   BlockActionEntry,
@@ -3667,5 +3679,6 @@ export {
   EntryWithBumperWitNoSources,
   EntryWithBumper as EntryExternalCaptionNoKS,
   EntryWithBumperWithKs as EntryExternalCaptionWithKS,
-  EntryDirectWithKs
+  EntryDirectWithKs,
+  Session
 };

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -896,7 +896,7 @@ describe('getPlaybackContext', () => {
   });
 });
 
-describe('doRequest', () => {
+describe.only('doRequest', () => {
   let provider, params, sandbox;
   const partnerId = 1068292;
   const playerVersion = '1.2.3';
@@ -969,9 +969,8 @@ describe('doRequest', () => {
     provider
       .doRequest([{loader: OVPMediaEntryLoader, params}], ks)
       .then((data: Map<string, any>) => {
-        provider.ks.should.equals(ks);
         data.has(OVPSessionLoader.id).should.be.false;
-        provider.isAnonymous.should.be.false;
+        provider.isAnonymous.should.be.true;
         done();
       })
       .catch(err => {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -958,26 +958,6 @@ describe('doRequest', () => {
       });
   });
 
-  it('should use anonymous KS from provider', done => {
-    sandbox = sinon.createSandbox();
-    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
-      return new Promise(resolve => {
-        resolve({response: {}});
-      });
-    });
-    params.ks = ks;
-    provider.anonymousKs = ks;
-    provider
-      .doRequest([{loader: OVPMediaEntryLoader, params}])
-      .then((data: Map<string, any>) => {
-        data.has(OVPSessionLoader.id).should.be.false;
-        done();
-      })
-      .catch(err => {
-        done(err);
-      });
-  });
-
   it('should use external KS', done => {
     sandbox = sinon.createSandbox();
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -896,7 +896,7 @@ describe('getPlaybackContext', () => {
   });
 });
 
-describe.only('doRequest', () => {
+describe('doRequest', () => {
   let provider, params, sandbox;
   const partnerId = 1068292;
   const playerVersion = '1.2.3';

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -931,10 +931,8 @@ describe('doRequest', () => {
         data.has(OVPSessionLoader.id).should.be.true;
         data.get(OVPSessionLoader.id).response.should.equal(ks);
         provider.isAnonymous.should.be.true;
-        data.has(OVPMediaEntryLoader.id).should.be.true;
         const mediaLoader = data.get(OVPMediaEntryLoader.id);
-        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
-        request.params.ks.should.equal('{1:result:ks}');
+        mediaLoader._requests[1].params.ks.should.equal('{1:result:ks}');
         done();
       })
       .catch(err => {
@@ -956,8 +954,7 @@ describe('doRequest', () => {
       .then((data: Map<string, any>) => {
         data.has(OVPSessionLoader.id).should.be.false;
         const mediaLoader = data.get(OVPMediaEntryLoader.id);
-        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
-        request.params.ks.should.equal(provider.ks);
+        mediaLoader._requests[0].params.ks.should.equal(provider.ks);
         done();
       })
       .catch(err => {
@@ -980,8 +977,7 @@ describe('doRequest', () => {
         data.has(OVPSessionLoader.id).should.be.false;
         provider.isAnonymous.should.be.true;
         const mediaLoader = data.get(OVPMediaEntryLoader.id);
-        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
-        request.params.ks.should.equal(ks);
+        mediaLoader._requests[0].params.ks.should.equal(ks);
         done();
       })
       .catch(err => {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -969,6 +969,7 @@ describe('doRequest', () => {
     provider
       .doRequest([{loader: OVPMediaEntryLoader, params}], ks)
       .then((data: Map<string, any>) => {
+        provider.ks.should.equal('');
         data.has(OVPSessionLoader.id).should.be.false;
         provider.isAnonymous.should.be.true;
         done();

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -931,6 +931,10 @@ describe('doRequest', () => {
         data.has(OVPSessionLoader.id).should.be.true;
         data.get(OVPSessionLoader.id).response.should.equal(ks);
         provider.isAnonymous.should.be.true;
+        data.has(OVPMediaEntryLoader.id).should.be.true;
+        const mediaLoader = data.get(OVPMediaEntryLoader.id);
+        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
+        request.params.ks.should.equal('{1:result:ks}');
         done();
       })
       .catch(err => {
@@ -951,6 +955,9 @@ describe('doRequest', () => {
       .doRequest([{loader: OVPMediaEntryLoader, params}])
       .then((data: Map<string, any>) => {
         data.has(OVPSessionLoader.id).should.be.false;
+        const mediaLoader = data.get(OVPMediaEntryLoader.id);
+        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
+        request.params.ks.should.equal(provider.ks);
         done();
       })
       .catch(err => {
@@ -972,6 +979,9 @@ describe('doRequest', () => {
         provider.ks.should.equal('');
         data.has(OVPSessionLoader.id).should.be.false;
         provider.isAnonymous.should.be.true;
+        const mediaLoader = data.get(OVPMediaEntryLoader.id);
+        const request = mediaLoader._requests.find(request => request.service === 'baseEntry');
+        request.params.ks.should.equal(ks);
         done();
       })
       .catch(err => {


### PR DESCRIPTION
### Description of the Changes

**the issue:**
We are saving in provider only non-anonymous KS. When KS is then needed for BE requests, requests are failing.
Need to add KS to doRequest and keep ks for future API calls.

**solution:**
1. doRequest generates ks if doesn’t exist
2. doRequest should get external ks as parameter

Solves FEC-11696

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
