### PR TITLE
fix(FEC-11882): V3- Playlist/Related plugin - if entries list includes broken entry ID, the list doesn't load at all

### DIFF
--- a/src/k-provider/common/data-loader-manager.js
+++ b/src/k-provider/common/data-loader-manager.js
@@ -66,12 +66,13 @@ export default class DataLoaderManager {
 
   /**
    * Get data from all loaders using multi request
+   * @param {boolean} requestsMustSucceed whether all of the requests must succeed or not
    * @function
    * @returns {Promise} Promise
    */
-  fetchData(): Promise<any> {
+  fetchData(requestsMustSucceed?: boolean): Promise<any> {
     return new Promise((resolve, reject) => {
-      this._multiRequest.execute().then(
+      this._multiRequest.execute(requestsMustSucceed).then(
         data => {
           this._multiResponse = data.response;
           let preparedData: Object = this.prepareData(data.response);

--- a/src/k-provider/common/multi-request-builder.js
+++ b/src/k-provider/common/multi-request-builder.js
@@ -95,12 +95,13 @@ export class MultiRequestResult {
     const results = responseArr.map(result => new ServiceResult(result));
     const errorResults = this.results.filter(serviceResult => serviceResult.hasError);
 
+    errorResults.forEach(serviceResult => {
+      MultiRequestResult._logger.error(
+        `Service returned an error with error code: ${serviceResult.error.code} and message: ${serviceResult.error.message}.`
+      );
+    });
+
     if ((requestsMustSucceed && errorResults.length) || errorResults.length === this.results.length) {
-      errorResults.forEach(serviceResult => {
-        MultiRequestResult._logger.error(
-          `Service returned an error with error code: ${serviceResult.error.code} and message: ${serviceResult.error.message}.`
-        );
-      });
       this.results = results;
       this.success = false;
     } else {

--- a/src/k-provider/common/multi-request-builder.js
+++ b/src/k-provider/common/multi-request-builder.js
@@ -92,16 +92,19 @@ export class MultiRequestResult {
   constructor(response: Object, requestsMustSucceed?: boolean = true) {
     const result = response.result ? response.result : response;
     const responseArr = Array.isArray(result) ? result : [result];
-
-    this.results = responseArr.map(result => new ServiceResult(result));
+    const results = responseArr.map(result => new ServiceResult(result));
     const errorResults = this.results.filter(serviceResult => serviceResult.hasError);
 
     if ((requestsMustSucceed && errorResults.length) || errorResults.length === this.results.length) {
-      MultiRequestResult._logger.error(
-        `Service returned an error with error code: ${errorResults[0].error.code} and message: ${errorResults[0].error.message}.`
-      );
+      errorResults.forEach(serviceResult => {
+        MultiRequestResult._logger.error(
+          `Service returned an error with error code: ${serviceResult.error.code} and message: ${serviceResult.error.message}.`
+        );
+      });
+      this.results = results;
       this.success = false;
     } else {
+      this.results = this.results.filter(serviceResult => !serviceResult.hasError);
       this.success = true;
     }
   }

--- a/src/k-provider/ott/provider.js
+++ b/src/k-provider/ott/provider.js
@@ -161,7 +161,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
           this._dataLoader.add(OTTSessionLoader, {partnerId: this.partnerId});
         }
         this._dataLoader.add(OTTAssetListLoader, {entries, ks});
-        this._dataLoader.fetchData().then(
+        this._dataLoader.fetchData(false).then(
           response => {
             resolve(this._parseEntryListDataFromResponse(response, entries));
           },

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -258,7 +258,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         }
         const redirectFromEntryId = this._getEntryRedirectFilter(entryListInfo);
         this._dataLoader.add(OVPEntryListLoader, {entries, ks, redirectFromEntryId});
-        this._dataLoader.fetchData().then(
+        this._dataLoader.fetchData(false).then(
           response => {
             resolve(this._parseEntryListDataFromResponse(response));
           },

--- a/test/src/k-provider/ott/provider.spec.js
+++ b/test/src/k-provider/ott/provider.spec.js
@@ -313,6 +313,36 @@ describe('getEntryListConfig', function () {
       }
     );
   });
+
+  it('should load a partial playlist by entry list if some requests have an error', done => {
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
+      return new Promise(resolve => {
+        resolve({
+          response: new MultiRequestResult({
+            result: [...BE_DATA.AnonymousPlaylistByEntryList.response.result, BE_DATA.InvalidKSFormat.response.result.error]
+          })
+        });
+      });
+    });
+
+    provider.getEntryListConfig({entries: ['259153', {entryId: '258459'}], ks}).then(
+      entryListConfig => {
+        try {
+          entryListConfig.id.should.equal('');
+          entryListConfig.items.length.should.equal(2);
+          entryListConfig.metadata.name.should.equal('');
+          entryListConfig.metadata.description.should.equal('');
+          entryListConfig.poster.should.equal('');
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
 });
 
 describe('getEntryWithBumper', function () {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -797,6 +797,32 @@ describe('getEntryListConfig', function () {
       }
     );
   });
+
+  it('should load a partial playlist by entry list if some requests have an error', done => {
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult([...BE_DATA.PlaylistByEntryList.response, BE_DATA.WrongEntryIDWithoutUIConf.response])});
+      });
+    });
+
+    provider.getEntryListConfig({entries: ['0_nwkp7jtx', {entryId: '0_wifqaipd'}, '0_p8aigvgu'], ks}).then(
+      entryListConfig => {
+        try {
+          entryListConfig.id.should.equal('');
+          entryListConfig.items.length.should.equal(3);
+          entryListConfig.metadata.name.should.equal('');
+          entryListConfig.metadata.description.should.equal('');
+          entryListConfig.poster.should.equal('');
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
 });
 
 describe('getPlaybackContext', () => {


### PR DESCRIPTION
### Description of the Changes

Allow some of the entry list requests to fail without failing the entire multi request

Resolves FEC-11882

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
