### PR TITLE
fix(FEC-12243): simulive - The live stream will show the captions from the Simulive entry

### DIFF
--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -44,10 +44,10 @@ class OVPProviderParser {
     const kalturaSources = playbackContext.sources;
 
     mediaEntry.sources = OVPProviderParser._getParsedSources(kalturaSources, ks, partnerId, uiConfId, entry, playbackContext);
-    if (OVPConfiguration.get().useApiCaptions && playbackContext.data.playbackCaptions) {
+    OVPProviderParser._fillBaseData(mediaEntry, entry, metadataList);
+    if (mediaEntry.type !== MediaEntry.Type.LIVE && OVPConfiguration.get().useApiCaptions && playbackContext.data.playbackCaptions) {
       mediaEntry.sources.captions = ExternalCaptionsBuilder.createConfig(playbackContext.data.playbackCaptions, ks);
     }
-    OVPProviderParser._fillBaseData(mediaEntry, entry, metadataList);
     return mediaEntry;
   }
 

--- a/test/src/k-provider/ovp/provider-parser-data.js
+++ b/test/src/k-provider/ovp/provider-parser-data.js
@@ -21,7 +21,19 @@ const youtubeMediaEntryData = [
       hasError: false,
       data: {
         sources: [],
-        playbackCaptions: [],
+        playbackCaptions: [
+          {
+            label: 'Hebrew',
+            format: '1',
+            language: 'Hebrew',
+            webVttUrl:
+              'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_kwipd4sf/segmentIndex/-1/version/1/captions.vtt',
+            url: 'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/1_kwipd4sf',
+            isDefault: true,
+            languageCode: 'he',
+            objectType: 'KalturaCaptionPlaybackPluginData'
+          }
+        ],
         flavorAssets: [],
         actions: [],
         messages: [],
@@ -68,4 +80,61 @@ const youtubeMediaEntryResult = {
   poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001'
 };
 
-export {youtubeMediaEntryData, youtubeMediaEntryResult};
+const liveMediaEntryData = [
+  '',
+  1740481,
+  null,
+  {
+    entry: {
+      id: '1234',
+      status: 2,
+      referenceId: 'abcdefg',
+      name: 'test live entry',
+      description: 'live description',
+      dataUrl: 'https://cdnapisec.kaltura.com/p/1111/sp/1111/playManifest/entryId/1234/format/url/protocol/https',
+      type: 7,
+      entryType: 7,
+      duration: 0,
+      poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001',
+      tags: ''
+    },
+    playBackContextResult: {
+      hasError: false,
+      data: {
+        sources: [],
+        playbackCaptions: [
+          {
+            label: 'Hebrew',
+            format: '1',
+            language: 'Hebrew',
+            webVttUrl:
+              'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_kwipd4sf/segmentIndex/-1/version/1/captions.vtt',
+            url: 'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/1_kwipd4sf',
+            isDefault: true,
+            languageCode: 'he',
+            objectType: 'KalturaCaptionPlaybackPluginData'
+          }
+        ],
+        flavorAssets: [],
+        actions: [],
+        messages: [],
+        objectType: 'KalturaPlaybackContext'
+      },
+      sources: [],
+      actions: [],
+      messages: [],
+      flavorAssets: []
+    },
+    metadataListResult: {
+      hasError: false,
+      data: {
+        objects: [],
+        totalCount: 0,
+        objectType: 'KalturaMetadataListResponse'
+      },
+      totalCount: 0
+    }
+  }
+];
+
+export {youtubeMediaEntryData, youtubeMediaEntryResult, liveMediaEntryData};

--- a/test/src/k-provider/ovp/provider-parser.spec.js
+++ b/test/src/k-provider/ovp/provider-parser.spec.js
@@ -10,7 +10,7 @@ import {
   kalturaSourceProtocolMismatch,
   kalturaSourceProtocolMismatchFlavorAssets
 } from './playback-sources-data';
-import {youtubeMediaEntryResult, youtubeMediaEntryData} from './provider-parser-data';
+import {youtubeMediaEntryResult, youtubeMediaEntryData, liveMediaEntryData} from './provider-parser-data';
 
 describe('provider parser', function () {
   let sandbox;
@@ -80,6 +80,18 @@ describe('provider parser', function () {
       const mediaEntryObject = mediaEntry.toJSON();
       Object.keys(mediaEntryObject).forEach(key => mediaEntryObject[key] === undefined && delete mediaEntryObject[key]);
       mediaEntryObject.should.deep.equal(youtubeMediaEntryResult);
+    });
+
+    it('should add external captions to the media sources', () => {
+      const mediaEntry = OVPProviderParser.getMediaEntry(...youtubeMediaEntryData);
+      mediaEntry.sources.should.haveOwnProperty('captions');
+      mediaEntry.sources.captions.length.should.equal(1);
+    });
+
+    it('should not add external captions to live media', () => {
+      const mediaEntry = OVPProviderParser.getMediaEntry(...liveMediaEntryData);
+      console.log(mediaEntry.sources);
+      mediaEntry.sources.should.not.haveOwnProperty('captions');
     });
   });
 });

--- a/test/src/k-provider/ovp/provider-parser.spec.js
+++ b/test/src/k-provider/ovp/provider-parser.spec.js
@@ -90,7 +90,6 @@ describe('provider parser', function () {
 
     it('should not add external captions to live media', () => {
       const mediaEntry = OVPProviderParser.getMediaEntry(...liveMediaEntryData);
-      console.log(mediaEntry.sources);
       mediaEntry.sources.should.not.haveOwnProperty('captions');
     });
   });


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when playing simulive entry with external captions and the player fallbacks to real live stream - the captions from the simulive entry are displayed on the live stream.

**the solution:**
add captions source to the mediaEntry sources only if the media type is not live.
Note- needed to move fillBaseData before the if block in order to have mediaEntry.type initialized.

Solves FEC-12243

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
