### PR TITLE
fix(FEC-12588): 360 player loads whenever you have a tag that contains 360 (ie. wells360fargo)

### DIFF
--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -331,7 +331,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (mediaEntry.sources.captions) {
       sourcesObject.captions = mediaEntry.sources.captions;
     }
-    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.indexOf('360') > -1) {
+    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.search(/\b360\b/) > -1) {
       sourcesObject.vr = {};
     }
     Object.assign(sourcesObject.metadata, mediaEntry.metadata);


### PR DESCRIPTION
### Description of the Changes

**the issue:**
if entry has a tag that contains 360 string with another characters for example: wells360fargo
the player activate the vr plugin even that is not 360 media.

**the root cause:**
the player activate the vr plugin if there is sequence of 360 in the list of the tags

**the solution:**
change the check that only if exists tag 360 without any other characters the vr plugin will be activated. 

solves: FEC-12588

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
