### PR TITLE
feat(FEC-12850): ECDN Fallback Option Upon Inaccessible API Gateway

### DIFF
--- a/flow-typed/types/env-config.js
+++ b/flow-typed/types/env-config.js
@@ -3,5 +3,6 @@ declare type ProviderEnvConfigObject = {
   serviceUrl: string,
   cdnUrl?: string,
   analyticsServiceUrl?: string,
-  useApiCaptions?: boolean
+  useApiCaptions?: boolean,
+  replaceECDNAllUrls?: boolean
 };

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -11,5 +11,6 @@ declare type ProviderOptionsObject = {
   networkRetryParameters?: ProviderNetworkRetryParameters,
   filterOptions?: ProviderFilterOptionsObject,
   ignoreServerConfig?: boolean,
-  loadThumbnailWithKs?: boolean
+  loadThumbnailWithKs?: boolean,
+  replaceECDNAllUrls?: boolean
 };

--- a/src/k-provider/ovp/config.js
+++ b/src/k-provider/ovp/config.js
@@ -9,7 +9,8 @@ const defaultConfig: Object = {
     format: 1
   },
   useApiCaptions: true,
-  loadThumbnailWithKs: false
+  loadThumbnailWithKs: false,
+  replaceECDNAllUrls: true
 };
 
 export default class OVPConfiguration {

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -528,22 +528,6 @@ class OVPProviderParser {
           cdnUrl = cdnUrl.replace(regExp, regexAction.replacement);
           if (regexAction.checkAliveTimeoutMs && regexAction.checkAliveTimeoutMs > 0) {
             const urlPing = cdnUrl + '/api_v3/service/system/action/ping/format/1';
-            // http://kesqa1.ecdn.kaltura.io/kAPI/qa-apache-php7.dev.kaltura.com/api_v3/service/system/action/ping/format/1
-
-            // const controller = new AbortController();
-            // const timeoutId = setTimeout(() => {
-            //   controller.abort();
-            // }, regexAction.checkAliveTimeoutMs);
-            //
-            // fetch(urlPing, {
-            //   signal: controller.signal
-            // })
-            //   .then(response => {
-            //     resolve(response.ok);
-            //   })
-            //   .catch(() => resolve(false))
-            //   .finally(clearTimeout(timeoutId));
-
             const req = new XMLHttpRequest();
             req.open('GET', urlPing);
             req.timeout = regexAction.checkAliveTimeoutMs;

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -143,27 +143,18 @@ class OVPProviderParser {
    * @param {any} assetResponse - The asset response.
    * @param {string} ks - The ks
    * @param {number} partnerId - The partner ID
-   * @param {boolean} shouldReplaceUrlsWithRegex - Indicates whether the bumper url should be replaced with regex
    * @returns {?Bumper} - The bumper
    * @static
    * @public
    */
-  static getBumper(assetResponse: any, ks: string, partnerId: number, shouldReplaceUrlsWithRegex: boolean): ?Bumper {
+  static getBumper(assetResponse: any, ks: string, partnerId: number): ?Bumper {
     const playbackContext = assetResponse.playBackContextResult;
     const bumperData: KalturaBumper = playbackContext.bumperData[0];
     if (bumperData) {
       const bumperSources = bumperData && bumperData.sources;
       const progressiveBumper = bumperSources.find(bumper => isProgressiveSource(bumper.format));
       if (progressiveBumper) {
-        const parsedSources = OVPProviderParser._parseProgressiveSources(
-          progressiveBumper,
-          playbackContext,
-          ks,
-          partnerId,
-          0,
-          bumperData.entryId,
-          shouldReplaceUrlsWithRegex && OVPConfiguration.get().replaceECDNAllUrls
-        );
+        const parsedSources = OVPProviderParser._parseProgressiveSources(progressiveBumper, playbackContext, ks, partnerId, 0, bumperData.entryId);
         if (parsedSources[0]) {
           return new Bumper({url: parsedSources[0].url, clickThroughUrl: bumperData.clickThroughUrl});
         }

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -152,13 +152,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
             });
           }
           return new Promise(resolve => {
-            OVPProviderParser.getMediaEntry(this.isAnonymous ? '' : this.ks, this.partnerId, this.uiConfId, response).then(arrayResult => {
-              const mediaEntry = arrayResult[0];
-              const shouldReplaceRegex = arrayResult[1];
+            OVPProviderParser.getMediaEntry(this.isAnonymous ? '' : this.ks, this.partnerId, this.uiConfId, response).then(mediaEntry => {
               Object.assign(mediaConfig.sources, this._getSourcesObject(mediaEntry));
               this._verifyMediaStatus(mediaEntry);
               this._verifyHasSources(mediaConfig.sources);
-              const bumper = OVPProviderParser.getBumper(response, this.isAnonymous ? '' : this.ks, this.partnerId, shouldReplaceRegex);
+              const bumper = OVPProviderParser.getBumper(response, this.isAnonymous ? '' : this.ks, this.partnerId);
               if (bumper) {
                 Object.assign(mediaConfig.plugins, {bumper});
               }

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -151,19 +151,24 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
               messages: OVPProviderParser.getErrorMessages(response)
             });
           }
-          const mediaEntry = OVPProviderParser.getMediaEntry(this.isAnonymous ? '' : this.ks, this.partnerId, this.uiConfId, response);
-          Object.assign(mediaConfig.sources, this._getSourcesObject(mediaEntry));
-          this._verifyMediaStatus(mediaEntry);
-          this._verifyHasSources(mediaConfig.sources);
-          const bumper = OVPProviderParser.getBumper(response, this.isAnonymous ? '' : this.ks, this.partnerId);
-          if (bumper) {
-            Object.assign(mediaConfig.plugins, {bumper});
-          }
+          return new Promise(resolve => {
+            OVPProviderParser.getMediaEntry(this.isAnonymous ? '' : this.ks, this.partnerId, this.uiConfId, response).then(arrayResult => {
+              const mediaEntry = arrayResult[0];
+              const shouldReplaceRegex = arrayResult[1];
+              Object.assign(mediaConfig.sources, this._getSourcesObject(mediaEntry));
+              this._verifyMediaStatus(mediaEntry);
+              this._verifyHasSources(mediaConfig.sources);
+              const bumper = OVPProviderParser.getBumper(response, this.isAnonymous ? '' : this.ks, this.partnerId, shouldReplaceRegex);
+              if (bumper) {
+                Object.assign(mediaConfig.plugins, {bumper});
+              }
+              this._logger.debug('Data parsing finished', mediaConfig);
+              resolve(mediaConfig);
+            });
+          });
         }
       }
     }
-    this._logger.debug('Data parsing finished', mediaConfig);
-    return mediaConfig;
   }
 
   /**

--- a/src/k-provider/ovp/response-types/kaltura-access-control-modify-request-host-regex-action.js
+++ b/src/k-provider/ovp/response-types/kaltura-access-control-modify-request-host-regex-action.js
@@ -17,6 +17,11 @@ export class KalturaAccessControlModifyRequestHostRegexAction extends KalturaRul
    * @type {number}
    */
   replacmenServerNodeId: number;
+  /**
+   * @member - checkAliveTimeout in milliseconds
+   * @type {number}
+   */
+  checkAliveTimeoutMs: number;
 
   /**
    * @constructor
@@ -27,5 +32,6 @@ export class KalturaAccessControlModifyRequestHostRegexAction extends KalturaRul
     this.pattern = data.pattern;
     this.replacement = data.replacement;
     this.replacmenServerNodeId = data.replacmenServerNodeId;
+    this.checkAliveTimeoutMs = data.checkAliveTimeoutMs;
   }
 }


### PR DESCRIPTION
### Description of the Changes

apply regex host replacement to urls only if the API gateway is accessible; otherwise use fallback -> do not replace and keep the original urls:
- make a ping request of the configured cdn to check if accessible, before parsing the sources
- the ping request should be executed only when there is accessControlActions configured with a regexAction
- we should apply the regex replacement only if a ping was made and it was successful
- add configuration `replaceECDNAllUrls` with default `true`, which indicates whether only playManifest urls should be applied with the regex, or we should apply it also to poster and captions urls

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
