### PR TITLE
feat(FEC-12850): ECDN Fallback Option Upon Inaccessible API Gateway

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,3 +2,4 @@
 .*/node_modules/.*
 [include]
 [options]
+esproposal.optional_chaining=enable

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,8 @@ var provider = new playkit.providers.ott.Provider(config);
 > {
 >  serviceUrl: string,
 >  cdnUrl: string,
->  useApiCaptions: boolean
+>  useApiCaptions: boolean,
+>  replaceECDNAllUrls: boolean // optional
 > }
 > ```
 >
@@ -110,7 +111,8 @@ var provider = new playkit.providers.ott.Provider(config);
 > {
 >  serviceUrl: "//www.kaltura.com/api_v3",
 >  cdnUrl: "//cdnapisec.kaltura.com",
->  useApiCaptions: true
+>  useApiCaptions: true,
+>  replaceECDNAllUrls: true
 > }
 > ```
 >
@@ -132,6 +134,14 @@ var provider = new playkit.providers.ott.Provider(config);
 > > ##### Default: true
 > >
 > > ##### Description: Show captions on platforms that don't support inband captions (for example: playing using Flash). This flag is for the OVP provider, and can be turned off by setting its value to `false`.
+>
+> > ### config.env.replaceECDNAllUrls
+> >
+> > ##### Type: `boolean`
+> >
+> > ##### Default: true
+> >
+> > ##### Description: Defines whether to modify captions and poster URLs, in addition to play manifest URLs. This flag is for OVP provider, and can be turned off by setting its value to `false`.
 
 ##
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ var provider = new playkit.providers.ott.Provider(config);
 >  serviceUrl: string,
 >  cdnUrl: string,
 >  useApiCaptions: boolean,
->  replaceECDNAllUrls: boolean // optional
+>  replaceHostOnlyManifestUrls: boolean // optional
 > }
 > ```
 >
@@ -112,7 +112,7 @@ var provider = new playkit.providers.ott.Provider(config);
 >  serviceUrl: "//www.kaltura.com/api_v3",
 >  cdnUrl: "//cdnapisec.kaltura.com",
 >  useApiCaptions: true,
->  replaceECDNAllUrls: true
+>  replaceHostOnlyManifestUrls: false
 > }
 > ```
 >
@@ -135,13 +135,13 @@ var provider = new playkit.providers.ott.Provider(config);
 > >
 > > ##### Description: Show captions on platforms that don't support inband captions (for example: playing using Flash). This flag is for the OVP provider, and can be turned off by setting its value to `false`.
 >
-> > ### config.env.replaceECDNAllUrls
+> > ### config.env.replaceHostOnlyManifestUrls
 > >
 > > ##### Type: `boolean`
 > >
-> > ##### Default: true
+> > ##### Default: false
 > >
-> > ##### Description: Defines whether to modify captions and poster URLs, in addition to play manifest URLs. This flag is for OVP provider, and can be turned off by setting its value to `false`.
+> > ##### Description: Defines whether to replace host only for play manifest URLs or to replace also for captions and poster URLs. This flag is for OVP provider, and can be turned on by setting its value to `true`.
 
 ##
 

--- a/flow-typed/types/env-config.js
+++ b/flow-typed/types/env-config.js
@@ -4,5 +4,5 @@ declare type ProviderEnvConfigObject = {
   cdnUrl?: string,
   analyticsServiceUrl?: string,
   useApiCaptions?: boolean,
-  replaceECDNAllUrls?: boolean
+  replaceHostOnlyManifestUrls?: boolean
 };

--- a/flow-typed/types/env-config.js
+++ b/flow-typed/types/env-config.js
@@ -3,5 +3,6 @@ declare type ProviderEnvConfigObject = {
   serviceUrl: string,
   cdnUrl?: string,
   analyticsServiceUrl?: string,
-  useApiCaptions?: boolean
+  useApiCaptions?: boolean,
+  replaceECDNAllUrls?: boolean
 };

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -11,6 +11,5 @@ declare type ProviderOptionsObject = {
   networkRetryParameters?: ProviderNetworkRetryParameters,
   filterOptions?: ProviderFilterOptionsObject,
   ignoreServerConfig?: boolean,
-  loadThumbnailWithKs?: boolean,
-  replaceECDNAllUrls?: boolean
+  loadThumbnailWithKs?: boolean
 };

--- a/flow-typed/types/provider-options.js
+++ b/flow-typed/types/provider-options.js
@@ -11,5 +11,6 @@ declare type ProviderOptionsObject = {
   networkRetryParameters?: ProviderNetworkRetryParameters,
   filterOptions?: ProviderFilterOptionsObject,
   ignoreServerConfig?: boolean,
-  loadThumbnailWithKs?: boolean
+  loadThumbnailWithKs?: boolean,
+  replaceECDNAllUrls?: boolean
 };

--- a/src/k-provider/ovp/config.js
+++ b/src/k-provider/ovp/config.js
@@ -10,7 +10,7 @@ const defaultConfig: Object = {
   },
   useApiCaptions: true,
   loadThumbnailWithKs: false,
-  replaceECDNAllUrls: true
+  replaceHostOnlyManifestUrls: false
 };
 
 export default class OVPConfiguration {

--- a/src/k-provider/ovp/config.js
+++ b/src/k-provider/ovp/config.js
@@ -9,7 +9,8 @@ const defaultConfig: Object = {
     format: 1
   },
   useApiCaptions: true,
-  loadThumbnailWithKs: false
+  loadThumbnailWithKs: false,
+  replaceECDNAllUrls: true
 };
 
 export default class OVPConfiguration {

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -312,7 +312,6 @@ class OVPProviderParser {
         OVPProviderParser._logger.warn(message);
         return null;
       }
-      // mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
       mediaSource.url = playUrl;
       mediaSource.id = entryId + '_' + deliveryProfileId + ',' + format;
       if (kalturaSource.hasDrmData()) {
@@ -376,7 +375,6 @@ class OVPProviderParser {
           OVPProviderParser._logger.warn(`failed to create play url from source, discarding source: (${entryId}_${deliveryProfileId}), ${format}.`);
           return null;
         } else {
-          // mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
           mediaSource.url = playUrl;
           if (flavor.height && flavor.width) {
             videoSources.push(mediaSource);

--- a/src/k-provider/ovp/provider-parser.js
+++ b/src/k-provider/ovp/provider-parser.js
@@ -312,7 +312,8 @@ class OVPProviderParser {
         OVPProviderParser._logger.warn(message);
         return null;
       }
-      mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
+      // mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
+      mediaSource.url = playUrl;
       mediaSource.id = entryId + '_' + deliveryProfileId + ',' + format;
       if (kalturaSource.hasDrmData()) {
         const drmParams: Array<Drm> = [];
@@ -375,7 +376,8 @@ class OVPProviderParser {
           OVPProviderParser._logger.warn(`failed to create play url from source, discarding source: (${entryId}_${deliveryProfileId}), ${format}.`);
           return null;
         } else {
-          mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
+          // mediaSource.url = OVPProviderParser._applyRegexAction(playbackContext, playUrl);
+          mediaSource.url = playUrl;
           if (flavor.height && flavor.width) {
             videoSources.push(mediaSource);
           } else {
@@ -446,26 +448,6 @@ class OVPProviderParser {
 
   static getErrorMessages(response: OVPMediaEntryLoaderResponse): Array<KalturaAccessControlMessage> {
     return response.playBackContextResult.getErrorMessages();
-  }
-
-  /**
-   * Applies the request host regex on the url
-   * @function _applyRegexAction
-   * @param {KalturaPlaybackContext} playbackContext - The playback context
-   * @param {string} playUrl - The original url
-   * @returns {string} - The request host regex applied url
-   * @static
-   * @private
-   */
-  static _applyRegexAction(playbackContext: KalturaPlaybackContext, playUrl: string): string {
-    const regexAction = playbackContext.getRequestHostRegexAction();
-    if (regexAction) {
-      const regex = new RegExp(regexAction.pattern, 'i');
-      if (playUrl.match(regex)) {
-        return playUrl.replace(regex, regexAction.replacement + '/');
-      }
-    }
-    return playUrl;
   }
 }
 

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -61,8 +61,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
           response => {
             try {
               const mediaConfig = this._parseDataFromResponse(response);
-              const finalMediaConfig = RegexActionHandler.handleRegexAction(mediaConfig, response);
-              resolve(finalMediaConfig);
+              RegexActionHandler.handleRegexAction(mediaConfig, response).then(resolve);
             } catch (err) {
               reject(err);
             }

--- a/src/k-provider/ovp/provider.js
+++ b/src/k-provider/ovp/provider.js
@@ -11,6 +11,7 @@ import BaseProvider from '../common/base-provider';
 import MediaEntry from '../../entities/media-entry';
 import OVPEntryListLoader from './loaders/entry-list-loader';
 import Error from '../../util/error/error';
+import RegexActionHandler from './regex-action-handler';
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
@@ -59,7 +60,9 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         return this._dataLoader.fetchData().then(
           response => {
             try {
-              resolve(this._parseDataFromResponse(response));
+              const mediaConfig = this._parseDataFromResponse(response);
+              const finalMediaConfig = RegexActionHandler.handleRegexAction(mediaConfig, response);
+              resolve(finalMediaConfig);
             } catch (err) {
               reject(err);
             }

--- a/src/k-provider/ovp/regex-action-handler.js
+++ b/src/k-provider/ovp/regex-action-handler.js
@@ -1,0 +1,147 @@
+//@flow
+import getLogger from '../../util/logger';
+import OVPConfiguration from './config';
+import {KalturaAccessControlModifyRequestHostRegexAction} from './response-types';
+import OVPMediaEntryLoader from './loaders/media-entry-loader';
+
+class RegexActionHandler {
+  static _logger = getLogger('RegexActionHandler');
+
+  /**
+   * Applies the request host regex on the url
+   * @function _applyRegexAction
+   * @param {KalturaAccessControlModifyRequestHostRegexAction} regexAction - The regex action
+   * @param {string} url - The url to modify
+   * @returns {string} - The request host regex applied url
+   * @static
+   * @private
+   */
+  static _applyRegexAction(regexAction: KalturaAccessControlModifyRequestHostRegexAction, url: string): string {
+    if (regexAction) {
+      const regex = new RegExp(regexAction.pattern, 'i');
+      if (url.match(regex)) {
+        return url.replace(regex, regexAction.replacement + '/');
+      }
+    }
+    return url;
+  }
+
+  /**
+   * Ping the ECDN url and modify urls if needed
+   * @function _pingECDNAndReplaceUrls
+   * @param {ProviderMediaConfigObject} mediaConfig - The media config
+   * @param {KalturaAccessControlModifyRequestHostRegexAction} regexAction - The regex action
+   * @param {string} urlPing - The url to ping
+   * @returns {Promise<ProviderMediaConfigObject>} - The media config with old or modified urls
+   * @static
+   * @private
+   */
+  static _pingECDNAndReplaceUrls(
+    mediaConfig: ProviderMediaConfigObject,
+    regexAction: KalturaAccessControlModifyRequestHostRegexAction,
+    urlPing: string
+  ): Promise<ProviderMediaConfigObject> {
+    return new Promise(resolve => {
+      const req = new XMLHttpRequest();
+      req.open('GET', urlPing);
+      req.timeout = regexAction.checkAliveTimeoutMs;
+      req.onreadystatechange = () => {
+        if (req.readyState === 4) {
+          if (req.status === 200) {
+            RegexActionHandler._modifyUrls(mediaConfig, regexAction);
+          }
+          resolve(mediaConfig);
+        }
+      };
+      req.ontimeout = () => {
+        RegexActionHandler._logger.warn(`Got timeout while pinging the ECDN url. ping url: ${urlPing}`);
+        resolve(mediaConfig);
+      };
+      req.send();
+    });
+  }
+
+  /**
+   * Handles regex action
+   * @function handleRegexAction
+   * @param {ProviderMediaConfigObject} mediaConfig - The media config
+   * @param {Map<string, Function>} data - The response data
+   * @returns {ProviderMediaConfigObject} - The media config with old or modified urls
+   * @static
+   */
+  static async handleRegexAction(mediaConfig: ProviderMediaConfigObject, data: Map<string, Function>): ProviderMediaConfigObject {
+    let cdnUrl = OVPConfiguration.get()?.cdnUrl || '';
+    const regexAction = RegexActionHandler._extractRegexActionFromData(data);
+    if (regexAction && regexAction.pattern && regexAction.replacement) {
+      const regExp = new RegExp(regexAction.pattern, 'i');
+      if (cdnUrl.match(regExp)) {
+        cdnUrl = cdnUrl.replace(regExp, regexAction.replacement);
+        if (regexAction.checkAliveTimeoutMs && regexAction.checkAliveTimeoutMs > 0) {
+          let urlToPing = cdnUrl + '/api_v3/service/system/action/ping/format/1';
+          const finalMediaConfig = await RegexActionHandler._pingECDNAndReplaceUrls(mediaConfig, regexAction, urlToPing);
+          return finalMediaConfig;
+        } else {
+          RegexActionHandler._modifyUrls(mediaConfig, regexAction);
+          return mediaConfig;
+        }
+      }
+    } else {
+      return mediaConfig;
+    }
+  }
+
+  /**
+   * Modify the urls
+   * @function _modifyUrls
+   * @param {ProviderMediaConfigObject} mediaConfig - The media config
+   * @param {KalturaAccessControlModifyRequestHostRegexAction} regexAction - The regex action
+   * @returns {void}
+   * @static
+   * @private
+   */
+  static _modifyUrls(mediaConfig: ProviderMediaConfigObject, regexAction: KalturaAccessControlModifyRequestHostRegexAction) {
+    RegexActionHandler._logger.debug(`Starting to modify urls...`);
+    const sources = mediaConfig.sources;
+    if (sources.hls.length > 0) {
+      sources.hls.forEach(src => (src.url = RegexActionHandler._applyRegexAction(regexAction, src.url)));
+    }
+    if (sources.dash.length > 0) {
+      sources.dash.forEach(src => (src.url = RegexActionHandler._applyRegexAction(regexAction, src.url)));
+    }
+    if (sources.progressive.length > 0) {
+      sources.progressive.forEach(src => (src.url = RegexActionHandler._applyRegexAction(regexAction, src.url)));
+    }
+    if (sources.image.length > 0) {
+      sources.image.forEach(src => (src.url = RegexActionHandler._applyRegexAction(regexAction, src.url)));
+    }
+    if (OVPConfiguration.get().replaceECDNAllUrls) {
+      if (sources.captions.length > 0) {
+        sources.captions.forEach(src => (src.url = RegexActionHandler._applyRegexAction(regexAction, src.url)));
+      }
+      if (sources.poster) {
+        sources.poster = RegexActionHandler._applyRegexAction(regexAction, sources.poster);
+      }
+    }
+    RegexActionHandler._logger.debug(`Finished modifying urls`);
+  }
+
+  /**
+   * Extracts the regex action from the data response
+   * @function _extractRegexActionFromData
+   * @param {Map<string, Function>} data - The response data
+   * @returns {KalturaAccessControlModifyRequestHostRegexAction} regexAction - The regex action
+   * @static
+   * @private
+   */
+  static _extractRegexActionFromData(data: any): ?KalturaAccessControlModifyRequestHostRegexAction {
+    if (data.has(OVPMediaEntryLoader.id)) {
+      const mediaLoader = data.get(OVPMediaEntryLoader.id);
+      if (mediaLoader && mediaLoader.response) {
+        const response = (mediaLoader: OVPMediaEntryLoader).response;
+        return response.playBackContextResult.getRequestHostRegexAction();
+      }
+    }
+  }
+}
+
+export default RegexActionHandler;

--- a/src/k-provider/ovp/response-types/kaltura-access-control-modify-request-host-regex-action.js
+++ b/src/k-provider/ovp/response-types/kaltura-access-control-modify-request-host-regex-action.js
@@ -17,7 +17,11 @@ export class KalturaAccessControlModifyRequestHostRegexAction extends KalturaRul
    * @type {number}
    */
   replacmenServerNodeId: number;
-
+  /**
+   * @member - checkAliveTimeout in milliseconds
+   * @type {number}
+   */
+  checkAliveTimeoutMs: number;
   /**
    * @constructor
    * @param {Object} data - The response
@@ -27,5 +31,6 @@ export class KalturaAccessControlModifyRequestHostRegexAction extends KalturaRul
     this.pattern = data.pattern;
     this.replacement = data.replacement;
     this.replacmenServerNodeId = data.replacmenServerNodeId;
+    this.checkAliveTimeoutMs = data.checkAliveTimeoutMs;
   }
 }

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -411,6 +411,19 @@ AnonymousMocEntryWithRequestHostRegexAction.response[2].actions = [
     objectType: 'KalturaAccessControlModifyRequestHostRegexAction'
   }
 ];
+AnonymousMocEntryWithRequestHostRegexAction.response[2].playbackCaptions = [
+  {
+    label: 'English',
+    format: '2',
+    language: 'English',
+    webVttUrl:
+      'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt',
+    url: 'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/1_6jfbcdz9/v/11',
+    isDefault: true,
+    languageCode: 'en',
+    objectType: 'KalturaCaptionPlaybackPluginData'
+  }
+];
 
 const AnonymousMocEntryWithoutUIConfWithDrmData = {
   response: [

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -141,7 +141,6 @@ const NoPluginsNoDrm = {
 };
 
 const RegexAppliedPlayManifestSources = {
-  plugins: {},
   session: {
     isAnonymous: true,
     partnerId: 1082342,
@@ -288,7 +287,8 @@ const RegexAppliedPlayManifestSources = {
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE'
     }
-  }
+  },
+  plugins: {}
 };
 
 const RegexAppliedAllSources = {

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -140,14 +140,24 @@ const NoPluginsNoDrm = {
   }
 };
 
-const RegexAppliedSources = {
+const RegexAppliedPlayManifestSources = {
+  plugins: {},
   session: {
     isAnonymous: true,
     partnerId: 1082342,
     ks: 'OGM0ZWM0Y2IwOWI5ZjM0MDcyZmQ3YmYxNzBiMGEwNGYxNWQ0ZTcyOXwxMDgyMzQyOzEwODIzNDI7MTQ5MDExNTg5MzswOzE0OTAwMjk0OTMuMTY3ODswO3ZpZXc6Kix3aWRnZXQ6MTs7'
   },
-  plugins: {},
   sources: {
+    captions: [
+      {
+        default: true,
+        type: 'vtt',
+        language: 'en',
+        label: 'English',
+        url:
+          'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt'
+      }
+    ],
     hls: [
       {
         id: '1_rsrdfext_10091,applehttp',
@@ -278,6 +288,158 @@ const RegexAppliedSources = {
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE'
     }
+  }
+};
+
+const RegexAppliedAllSources = {
+  session: {
+    isAnonymous: true,
+    partnerId: 1082342,
+    ks: 'OGM0ZWM0Y2IwOWI5ZjM0MDcyZmQ3YmYxNzBiMGEwNGYxNWQ0ZTcyOXwxMDgyMzQyOzEwODIzNDI7MTQ5MDExNTg5MzswOzE0OTAwMjk0OTMuMTY3ODswO3ZpZXc6Kix3aWRnZXQ6MTs7'
+  },
+  plugins: {},
+  sources: {
+    hls: [
+      {
+        id: '1_rsrdfext_10091,applehttp',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/applehttp/flavorIds/1_ha0nqwz8,1_gw7u4nf1,1_rql6sqaa,1_sufd1yd9,1_9xvkk7a5,1_4typ4pat,1_n75294r4/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_rsrdfext_11241,applehttp',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/applehttp/flavorIds/1_ha0nqwz8,1_gw7u4nf1,1_rql6sqaa,1_sufd1yd9,1_9xvkk7a5,1_4typ4pat,1_n75294r4/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      }
+    ],
+    dash: [
+      {
+        id: '1_rsrdfext_11611,mpegdash',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/mpegdash/flavorIds/1_ha0nqwz8,1_gw7u4nf1,1_rql6sqaa,1_sufd1yd9,1_9xvkk7a5,1_4typ4pat,1_n75294r4/a.mpd',
+        mimetype: 'application/dash+xml'
+      },
+      {
+        id: '1_rsrdfext_11261,mpegdash',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/mpegdash/flavorIds/1_ha0nqwz8,1_gw7u4nf1,1_rql6sqaa,1_sufd1yd9,1_9xvkk7a5,1_4typ4pat,1_n75294r4/a.mpd',
+        mimetype: 'application/dash+xml'
+      }
+    ],
+    image: [],
+    progressive: [
+      {
+        id: '1_ha0nqwz810081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_ha0nqwz8/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 482304,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_gw7u4nf110081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_gw7u4nf1/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 686080,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rql6sqaa10081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_rql6sqaa/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 987136,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_sufd1yd910081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_sufd1yd9/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 1584128,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_9xvkk7a510081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_9xvkk7a5/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 2691072,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_4typ4pat10081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_4typ4pat/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 4227072,
+        width: 1920,
+        height: 1080,
+        label: 'Undefined'
+      },
+      {
+        id: '1_n75294r410081,url',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cdnapisec.kaltura.com/p/1082342/sp/108234200/playManifest/entryId/1_rsrdfext/protocol/https/format/url/flavorIds/1_n75294r4/a.mov',
+        mimetype: 'video/mp4',
+        bandwidth: 18454528,
+        width: 1920,
+        height: 1080,
+        label: 'English'
+      }
+    ],
+    id: '1_rsrdfext',
+    duration: 55,
+    type: 'Vod',
+    poster:
+      'http://qa-kes-ebu-01.dev.kaltura.com/kAPI/kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    dvr: false,
+    vr: null,
+    metadata: {
+      entryId: '1_rsrdfext',
+      name: 'FO21934-HDTX-SWE',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
+      tags: '',
+      OriginalFilename: 'FO21934-HDTX-SWE.mov',
+      Locale: 'sv_SE',
+      PropertyCode: 'FTA-nm',
+      SiteSection: 'tv-dc',
+      ContentType: 'clip',
+      BusinessUnit: 'Disney Channel',
+      Origin: 'IBMS',
+      PromoType: 'Show - TV',
+      StartDate: '1483225200',
+      EndDate: '1485903600',
+      AgeConsent: 'No Age Consent',
+      TXID: 'FO21934-HDTX-SWE',
+      ZeroTouchIds: 'se-dc-lf',
+      ScheduleSource: 'VOD',
+      HLSOnly: 'android',
+      ChannelName: 'Disney Channel SE'
+    },
+    captions: [
+      {
+        default: true,
+        type: 'vtt',
+        language: 'en',
+        label: 'English',
+        url:
+          'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt'
+      }
+    ]
   }
 };
 
@@ -1331,7 +1493,7 @@ const EntryOfPartner0 = {
 
 export {
   NoPluginsNoDrm,
-  RegexAppliedSources,
+  RegexAppliedPlayManifestSources,
   NoPluginsWithDrm,
   WithPluginsNoDrm,
   WithPluginsWithDrm,
@@ -1342,5 +1504,6 @@ export {
   EntryWithBumper,
   EntryWithBumperWithKs,
   EntryWithNoBumper,
-  EntryOfPartner0
+  EntryOfPartner0,
+  RegexAppliedAllSources
 };

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -90,27 +90,6 @@ describe('OVPProvider.partnerId:1082342', function () {
     );
   });
 
-  it('should apply the request host regex on the source urls', done => {
-    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
-      return new Promise(resolve => {
-        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});
-      });
-    });
-    provider.getMediaConfig({entryId: '1_rsrdfext'}).then(
-      mediaConfig => {
-        try {
-          mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.RegexAppliedSources);
-          done();
-        } catch (err) {
-          done(err);
-        }
-      },
-      err => {
-        done(err);
-      }
-    );
-  });
-
   it('should return config with plugins and without drm data', done => {
     provider = new OVPProvider({partnerId: partnerId, uiConfId: 38621471}, playerVersion);
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -112,7 +112,7 @@ describe('OVPProvider.partnerId:1082342', function () {
   });
 
   it('should apply the request host regex only to the playManifest source urls', done => {
-    OVPConfiguration.set({replaceECDNAllUrls: false});
+    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: false});
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -90,6 +90,49 @@ describe('OVPProvider.partnerId:1082342', function () {
     );
   });
 
+  it('should apply the request host regex to all source urls', done => {
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});
+      });
+    });
+    provider.getMediaConfig({entryId: '1_rsrdfext'}).then(
+      mediaConfig => {
+        try {
+          mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.RegexAppliedAllSources);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
+
+  it('should apply the request host regex only to the playManifest source urls', done => {
+    OVPConfiguration.set({replaceECDNAllUrls: false});
+    sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
+      return new Promise(resolve => {
+        resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});
+      });
+    });
+    provider.getMediaConfig({entryId: '1_rsrdfext'}).then(
+      mediaConfig => {
+        try {
+          mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.RegexAppliedPlayManifestSources);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
+
   it('should return config with plugins and without drm data', done => {
     provider = new OVPProvider({partnerId: partnerId, uiConfId: 38621471}, playerVersion);
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -112,7 +112,7 @@ describe('OVPProvider.partnerId:1082342', function () {
   });
 
   it('should apply the request host regex only to the playManifest source urls', done => {
-    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: true});
+    OVPConfiguration.set({replaceHostOnlyManifestUrls: true});
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -112,7 +112,7 @@ describe('OVPProvider.partnerId:1082342', function () {
   });
 
   it('should apply the request host regex only to the playManifest source urls', done => {
-    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: false});
+    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: true});
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithRequestHostRegexAction.response)});

--- a/test/src/k-provider/ovp/regex-action-handler-data.js
+++ b/test/src/k-provider/ovp/regex-action-handler-data.js
@@ -1,0 +1,794 @@
+const mediaConfig = {
+  session: {
+    isAnonymous: false,
+    partnerId: 2452771,
+    ks:
+      'djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+  },
+  sources: {
+    hls: [
+      {
+        id: '1_5w23wdlc_13942,applehttp',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_13952,applehttp',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_21633,applehttp',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      }
+    ],
+    dash: [
+      {
+        id: '1_5w23wdlc_4662,mpegdash',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      },
+      {
+        id: '1_5w23wdlc_12972,mpegdash',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      }
+    ],
+    progressive: [
+      {
+        id: '1_ww66hsaf5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ww66hsaf/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 475136,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rrq1jzct5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rrq1jzct/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 644096,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_fspz1moi5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_fspz1moi/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 886784,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_ujuxekvc5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ujuxekvc/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 1404928,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_82qidu4d5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_82qidu4d/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 2379776,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rul8tydo5642,url',
+        url:
+          'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 3714048,
+        width: 1920,
+        height: 1080,
+        label: 'Undefined'
+      }
+    ],
+    image: [],
+    id: '1_5w23wdlc',
+    duration: 206,
+    type: 'Vod',
+    poster: 'https://cfvod.kaltura.com/p/2452771/sp/245277100/thumbnail/entry_id/1_5w23wdlc/version/100011',
+    dvr: false,
+    vr: null,
+    metadata: {
+      name: 'Tips & Tricks for Better Videos - API Fallback',
+      description: 'In this video we discuss how to wrap up your video with some simple post production tips.',
+      tags:
+        'data administration, accessibility, video, search marketing, caption complete, cameras, music, video tips, video solutions, metadata, data classification, national institute for health and care excellence, data structures, presentation applications, effects, training videos, keywords (marketing), video tutorials, artistic expressions and media, video training, video editing, software',
+      entryId: '1_5w23wdlc'
+    },
+    captions: [
+      {
+        default: true,
+        type: 'vtt',
+        language: 'en',
+        label: 'English',
+        url:
+          'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt?ks=djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+      }
+    ]
+  },
+  plugins: {}
+};
+
+const responseDataFromBE = [
+  {
+    hasError: false,
+    data: {
+      objects: [
+        {
+          mediaType: 1,
+          dataUrl: 'https://cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/format/url/protocol/https',
+          flavorParamsIds: '0,487041,487051,487061,487071,487081,487091',
+          duration: 206,
+          msDuration: 206000,
+          id: '1_5w23wdlc',
+          name: 'Tips & Tricks for Better Videos - API Fallback',
+          description: 'In this video we discuss how to wrap up your video with some simple post production tips.',
+          tags:
+            'data administration, accessibility, video, search marketing, caption complete, cameras, music, video tips, video solutions, metadata, data classification, national institute for health and care excellence, data structures, presentation applications, effects, training videos, keywords (marketing), video tutorials, artistic expressions and media, video training, video editing, software',
+          status: 2,
+          type: 1,
+          thumbnailUrl: 'https://cfvod.kaltura.com/p/2452771/sp/245277100/thumbnail/entry_id/1_5w23wdlc/version/100011',
+          objectType: 'KalturaMediaEntry'
+        }
+      ],
+      totalCount: 1,
+      objectType: 'KalturaBaseEntryListResponse'
+    }
+  },
+  {
+    hasError: false,
+    data: {
+      sources: [
+        {
+          deliveryProfileId: 5642,
+          format: 'url',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/5642/protocol/https/format/url/name/a.mp4',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 3382,
+          format: 'hdnetworkmanifest',
+          protocols: 'https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/3382/protocol/https/format/hdnetworkmanifest/manifest.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 4662,
+          format: 'mpegdash',
+          protocols: 'http,https',
+          flavorIds: '1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/4662/protocol/https/format/mpegdash/manifest.mpd',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 72,
+          format: 'url',
+          protocols: 'http',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'http://cdnapi.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/72/protocol/http/format/url/name/a.mp4',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 92,
+          format: 'url',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/92/protocol/https/format/url/name/a.mp4',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 102,
+          format: 'hdnetwork',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/102/protocol/https/format/hdnetwork/manifest.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 13942,
+          format: 'applehttp',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/13942/protocol/https/format/applehttp/a.m3u8',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 122,
+          format: 'rtsp',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/122/protocol/https/format/rtsp/name/a.3gp',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 13952,
+          format: 'applehttp',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/13952/protocol/https/format/applehttp/a.m3u8',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 21633,
+          format: 'applehttp',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/21633/protocol/https/format/applehttp/a.m3u8',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 132,
+          format: 'hdnetworkmanifest',
+          protocols: 'http',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'http://cdnapi.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/132/protocol/http/format/hdnetworkmanifest/manifest.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 152,
+          format: 'rtmp',
+          protocols: 'rtmp,rtmpe,rtmpt,rtmpte',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'http://cdnapi.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/152/protocol/http/format/rtmp/a.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 162,
+          format: 'rtmp',
+          protocols: 'rtmp,rtmpe,rtmpt,rtmpte',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'http://cdnapi.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/162/protocol/http/format/rtmp/a.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 12972,
+          format: 'mpegdash',
+          protocols: 'http,https',
+          flavorIds: '1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/12972/protocol/https/format/mpegdash/manifest.mpd',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 5552,
+          format: 'url',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/5552/protocol/https/format/url/name/a.mp4',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 5612,
+          format: 'hdnetworkmanifest',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/5612/protocol/https/format/hdnetworkmanifest/manifest.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        },
+        {
+          deliveryProfileId: 5622,
+          format: 'hdnetworkmanifest',
+          protocols: 'http,https',
+          flavorIds: '1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo',
+          url:
+            'https://cdnapisec.kaltura.com/p/2452771/sp/2452771/playManifest/entryId/1_5w23wdlc/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/deliveryProfileId/5622/protocol/https/format/hdnetworkmanifest/manifest.f4m',
+          drm: [],
+          objectType: 'KalturaPlaybackSource'
+        }
+      ],
+      playbackCaptions: [
+        {
+          label: 'English',
+          format: '2',
+          language: 'English',
+          webVttUrl:
+            'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt',
+          url: 'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/1_6jfbcdz9/v/11',
+          isDefault: true,
+          languageCode: 'en',
+          objectType: 'KalturaCaptionPlaybackPluginData'
+        }
+      ],
+      flavorAssets: [
+        {
+          flavorParamsId: 487041,
+          width: 640,
+          height: 360,
+          bitrate: 464,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_ww66hsaf',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 11468,
+          tags: 'mobile,web,mbr,iphone,iphonenew',
+          fileExt: 'mp4',
+          createdAt: 1543337882,
+          updatedAt: 1543337882,
+          description: '',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        },
+        {
+          flavorParamsId: 487051,
+          width: 640,
+          height: 360,
+          bitrate: 629,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_rrq1jzct',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 15872,
+          tags: 'mobile,web,mbr,iphone,iphonenew',
+          fileExt: 'mp4',
+          createdAt: 1543337882,
+          updatedAt: 1543337882,
+          description: 'audio warnings: 2106,#Redundant bitrate.\n',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        },
+        {
+          flavorParamsId: 487061,
+          width: 640,
+          height: 360,
+          bitrate: 866,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_fspz1moi',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 21811,
+          tags: 'mobile,web,mbr,ipad,ipadnew,dash',
+          fileExt: 'mp4',
+          createdAt: 1543337882,
+          updatedAt: 1543337882,
+          description: 'audio warnings: 2106,#Redundant bitrate.\n',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        },
+        {
+          flavorParamsId: 487071,
+          width: 1280,
+          height: 720,
+          bitrate: 1372,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_ujuxekvc',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 34508,
+          tags: 'mobile,web,mbr,ipad,ipadnew,dash',
+          fileExt: 'mp4',
+          createdAt: 1543337882,
+          updatedAt: 1543337882,
+          description: '',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        },
+        {
+          flavorParamsId: 487081,
+          width: 1280,
+          height: 720,
+          bitrate: 2324,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_82qidu4d',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 58470,
+          tags: 'web,mbr,dash',
+          fileExt: 'mp4',
+          createdAt: 1543337883,
+          updatedAt: 1543337883,
+          description: 'audio warnings: 2106,#Redundant bitrate.\n',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        },
+        {
+          flavorParamsId: 487091,
+          width: 1920,
+          height: 1080,
+          bitrate: 3627,
+          frameRate: 23.976,
+          isOriginal: false,
+          isWeb: true,
+          containerFormat: 'isom',
+          videoCodecId: 'avc1',
+          status: 2,
+          language: 'Undefined',
+          isDefault: false,
+          id: '1_rul8tydo',
+          entryId: '1_5w23wdlc',
+          partnerId: 2452771,
+          version: '11',
+          size: 91340,
+          tags: 'web,mbr,dash',
+          fileExt: 'mp4',
+          createdAt: 1543337883,
+          updatedAt: 1543337883,
+          description: 'audio warnings: 2106,#Redundant bitrate.\n',
+          sizeInBytes: 0,
+          objectType: 'KalturaFlavorAsset'
+        }
+      ],
+      actions: [
+        {
+          pattern: '^(https?):\\/\\/([^\\/]+)(\\/)?',
+          replacement: '$1://kesdev2.ecdn.kaltura.io/kAPI/$2',
+          replacmenServerNodeId: 31042,
+          checkAliveTimeoutMs: 3000,
+          type: 7,
+          objectType: 'KalturaAccessControlModifyRequestHostRegexAction'
+        }
+      ],
+      messages: [],
+      bumperData: [],
+      objectType: 'KalturaPlaybackContext'
+    }
+  },
+  {
+    hasError: false,
+    data: {
+      objects: [],
+      totalCount: 0,
+      objectType: 'KalturaMetadataListResponse'
+    }
+  }
+];
+
+const finalMediaConfigAllSourcesModified = {
+  session: {
+    isAnonymous: false,
+    partnerId: 2452771,
+    ks:
+      'djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+  },
+  sources: {
+    hls: [
+      {
+        id: '1_5w23wdlc_13942,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_13952,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_21633,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      }
+    ],
+    dash: [
+      {
+        id: '1_5w23wdlc_4662,mpegdash',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      },
+      {
+        id: '1_5w23wdlc_12972,mpegdash',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      }
+    ],
+    progressive: [
+      {
+        id: '1_ww66hsaf5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ww66hsaf/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 475136,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rrq1jzct5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rrq1jzct/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 644096,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_fspz1moi5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_fspz1moi/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 886784,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_ujuxekvc5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ujuxekvc/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 1404928,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_82qidu4d5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_82qidu4d/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 2379776,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rul8tydo5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 3714048,
+        width: 1920,
+        height: 1080,
+        label: 'Undefined'
+      }
+    ],
+    image: [],
+    id: '1_5w23wdlc',
+    duration: 206,
+    type: 'Vod',
+    poster: 'https://kesdev2.ecdn.kaltura.io/kAPI/cfvod.kaltura.com/p/2452771/sp/245277100/thumbnail/entry_id/1_5w23wdlc/version/100011',
+    dvr: false,
+    vr: null,
+    metadata: {
+      name: 'Tips & Tricks for Better Videos - API Fallback',
+      description: 'In this video we discuss how to wrap up your video with some simple post production tips.',
+      tags:
+        'data administration, accessibility, video, search marketing, caption complete, cameras, music, video tips, video solutions, metadata, data classification, national institute for health and care excellence, data structures, presentation applications, effects, training videos, keywords (marketing), video tutorials, artistic expressions and media, video training, video editing, software',
+      entryId: '1_5w23wdlc'
+    },
+    captions: [
+      {
+        default: true,
+        type: 'vtt',
+        language: 'en',
+        label: 'English',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt?ks=djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+      }
+    ]
+  },
+  plugins: {}
+};
+
+const finalMediaConfigPlayManifestSourcesModified = {
+  session: {
+    isAnonymous: false,
+    partnerId: 2452771,
+    ks:
+      'djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+  },
+  sources: {
+    hls: [
+      {
+        id: '1_5w23wdlc_13942,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_13952,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      },
+      {
+        id: '1_5w23wdlc_21633,applehttp',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/applehttp/flavorIds/1_ww66hsaf,1_rrq1jzct,1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.m3u8',
+        mimetype: 'application/x-mpegURL'
+      }
+    ],
+    dash: [
+      {
+        id: '1_5w23wdlc_4662,mpegdash',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      },
+      {
+        id: '1_5w23wdlc_12972,mpegdash',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/mpegdash/flavorIds/1_fspz1moi,1_ujuxekvc,1_82qidu4d,1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mpd',
+        mimetype: 'application/dash+xml'
+      }
+    ],
+    progressive: [
+      {
+        id: '1_ww66hsaf5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ww66hsaf/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 475136,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rrq1jzct5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rrq1jzct/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 644096,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_fspz1moi5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_fspz1moi/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 886784,
+        width: 640,
+        height: 360,
+        label: 'Undefined'
+      },
+      {
+        id: '1_ujuxekvc5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_ujuxekvc/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 1404928,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_82qidu4d5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_82qidu4d/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 2379776,
+        width: 1280,
+        height: 720,
+        label: 'Undefined'
+      },
+      {
+        id: '1_rul8tydo5642,url',
+        url:
+          'https://kesdev2.ecdn.kaltura.io/kAPI/cdnapisec.kaltura.com/p/2452771/sp/245277100/playManifest/entryId/1_5w23wdlc/protocol/https/format/url/flavorIds/1_rul8tydo/ks/djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye/a.mp4',
+        mimetype: 'video/mp4',
+        bandwidth: 3714048,
+        width: 1920,
+        height: 1080,
+        label: 'Undefined'
+      }
+    ],
+    image: [],
+    id: '1_5w23wdlc',
+    duration: 206,
+    type: 'Vod',
+    poster: 'https://cfvod.kaltura.com/p/2452771/sp/245277100/thumbnail/entry_id/1_5w23wdlc/version/100011',
+    dvr: false,
+    vr: null,
+    metadata: {
+      name: 'Tips & Tricks for Better Videos - API Fallback',
+      description: 'In this video we discuss how to wrap up your video with some simple post production tips.',
+      tags:
+        'data administration, accessibility, video, search marketing, caption complete, cameras, music, video tips, video solutions, metadata, data classification, national institute for health and care excellence, data structures, presentation applications, effects, training videos, keywords (marketing), video tutorials, artistic expressions and media, video training, video editing, software',
+      entryId: '1_5w23wdlc'
+    },
+    captions: [
+      {
+        default: true,
+        type: 'vtt',
+        language: 'en',
+        label: 'English',
+        url:
+          'https://cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt?ks=djJ8MjQ1Mjc3MXyhyOLSgHHw2TboKYTpuv4_GBK5Gb6ZgvSVdp9-NmPMXqVHgjKMWt18mqV5Uf5L4-zZyvLaFn-4WLcHnP-jmCF9X0Ak9sQlBRYLRXGigdGfgsdJgwWWrbcDtUe848Zpm-9Rw8qWgaNXh_rvhKQvy1Ye'
+      }
+    ]
+  },
+  plugins: {}
+};
+
+export {mediaConfig, responseDataFromBE, finalMediaConfigAllSourcesModified, finalMediaConfigPlayManifestSourcesModified};

--- a/test/src/k-provider/ovp/regex-action-handler.spec.js
+++ b/test/src/k-provider/ovp/regex-action-handler.spec.js
@@ -15,7 +15,7 @@ describe('handleRegexAction', function () {
   });
 
   it('should modify all URLs', done => {
-    OVPConfiguration.set({replaceECDNAllUrls: true});
+    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: true});
     mediaConfigForTest = {...mediaConfig};
     RegexActionHandler.handleRegexAction(mediaConfigForTest, data).then(
       mediaConfigRes => {

--- a/test/src/k-provider/ovp/regex-action-handler.spec.js
+++ b/test/src/k-provider/ovp/regex-action-handler.spec.js
@@ -15,7 +15,7 @@ describe('handleRegexAction', function () {
   });
 
   it('should modify all URLs', done => {
-    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: false});
+    OVPConfiguration.set({replaceHostOnlyManifestUrls: false});
     mediaConfigForTest = {...mediaConfig};
     RegexActionHandler.handleRegexAction(mediaConfigForTest, data).then(
       mediaConfigRes => {

--- a/test/src/k-provider/ovp/regex-action-handler.spec.js
+++ b/test/src/k-provider/ovp/regex-action-handler.spec.js
@@ -1,6 +1,7 @@
 import {finalMediaConfigAllSourcesModified, mediaConfig, responseDataFromBE} from './regex-action-handler-data';
 import RegexActionHandler from '../../../../src/k-provider/ovp/regex-action-handler';
 import OVPMediaEntryLoader from '../../../../src/k-provider/ovp/loaders/media-entry-loader';
+import OVPConfiguration from '../../../../src/k-provider/ovp/config';
 
 describe('handleRegexAction', function () {
   let data = new Map();
@@ -14,6 +15,7 @@ describe('handleRegexAction', function () {
   });
 
   it('should modify all URLs', done => {
+    OVPConfiguration.set({replaceECDNAllUrls: true});
     mediaConfigForTest = {...mediaConfig};
     RegexActionHandler.handleRegexAction(mediaConfigForTest, data).then(
       mediaConfigRes => {

--- a/test/src/k-provider/ovp/regex-action-handler.spec.js
+++ b/test/src/k-provider/ovp/regex-action-handler.spec.js
@@ -1,0 +1,32 @@
+import {finalMediaConfigAllSourcesModified, mediaConfig, responseDataFromBE} from './regex-action-handler-data';
+import RegexActionHandler from '../../../../src/k-provider/ovp/regex-action-handler';
+import OVPMediaEntryLoader from '../../../../src/k-provider/ovp/loaders/media-entry-loader';
+
+describe('handleRegexAction', function () {
+  let data = new Map();
+  let mediaEntryLoader;
+  let mediaConfigForTest;
+
+  before(() => {
+    mediaEntryLoader = new OVPMediaEntryLoader({entryId: 'a', ks: 'a', redirectFromEntryId: true});
+    mediaEntryLoader.response = responseDataFromBE;
+    data.set('media', mediaEntryLoader);
+  });
+
+  it('should modify all URLs', done => {
+    mediaConfigForTest = {...mediaConfig};
+    RegexActionHandler.handleRegexAction(mediaConfigForTest, data).then(
+      mediaConfigRes => {
+        try {
+          mediaConfigRes.should.deep.eq(finalMediaConfigAllSourcesModified);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      err => {
+        done(err);
+      }
+    );
+  });
+});

--- a/test/src/k-provider/ovp/regex-action-handler.spec.js
+++ b/test/src/k-provider/ovp/regex-action-handler.spec.js
@@ -15,7 +15,7 @@ describe('handleRegexAction', function () {
   });
 
   it('should modify all URLs', done => {
-    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: true});
+    OVPConfiguration.set({replaceHostOnlyPlayManifestUrls: false});
     mediaConfigForTest = {...mediaConfig};
     RegexActionHandler.handleRegexAction(mediaConfigForTest, data).then(
       mediaConfigRes => {


### PR DESCRIPTION
### Description of the Changes

add support for ECDN fallback upon inaccessible API gateway:

- make a ping request of the configured cdn to check if accessible
- the ping request should be executed only when there is accessControlActions configured with a regexAction
- we should apply the regex replacement if a ping was made and it was successful, or regexAction exists and there is no timeout configured
- add new configuration `provider.env.replaceHostOnlyManifestUrls` with default `false`, which indicates whether only playManifest urls should be applied with the regex; when configured to true- only play manifest urls should be replaced. if configured to false- in addition to manifest urls, apply the regex action to poster and captions urls

solves FEC-12850

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
