### PR TITLE
fix(FEC-13146): Kava sent the View event 4 times

### DIFF
--- a/src/k-provider/ovp/services/analytics/analytics-service.js
+++ b/src/k-provider/ovp/services/analytics/analytics-service.js
@@ -30,6 +30,7 @@ export default class OVPAnalyticsService extends OVPService {
     request.service = SERVICE_NAME;
     request.action = 'trackEvent';
     request.method = 'GET';
+    request.retryConfig.maxAttempts = 1;
     request.tag = 'analytics-trackEvent';
     request.params = serviceParams;
     request.url = serviceUrl + '?service=' + request.service + '&action=' + request.action + '&' + param(request.params);


### PR DESCRIPTION
### Description of the Changes

**issue:** the request-builder retry mechanism `retryConfig.maxAttempts` parm set to 4 by default 
Therefore when it comes into action (for example in offline mode) it sends the same report 4 times in a row

**fix:** set retryConfig.maxAttempts to - 1 on Analytics-service

solves FEC-13146

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
