### PR TITLE
fix(FEC-14047): playkit-js-providers - add aspectRatio to media metadata

### DIFF
--- a/src/k-provider/ovp/provider-parser.ts
+++ b/src/k-provider/ovp/provider-parser.ts
@@ -179,11 +179,8 @@ class OVPProviderParser {
       playbackContext.flavorAssets[0].width && playbackContext.flavorAssets[0].height) {
 
       const {height, width} = playbackContext.flavorAssets[0];
-      mediaEntry.metadata.heightRatio = +Number(height / width).toFixed(2);
-    } else {
-      mediaEntry.metadata.heightRatio = 1.78;
+      mediaEntry.metadata.aspectRatio = +Number(width / height).toFixed(2);
     }
-
     return mediaEntry;
   }
 

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -35,7 +35,7 @@ const NoPluginsNoDrm = {
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE',
       tags: '',
-      heightRatio: 0.56
+      aspectRatio: 1.78
     },
     progressive: [
       {
@@ -290,7 +290,7 @@ const RegexAppliedPlayManifestSources = {
       ScheduleSource: 'VOD',
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE',
-      heightRatio: 0.56
+      aspectRatio: 1.78
     },
     downloadUrl: ''
   },
@@ -436,7 +436,7 @@ const RegexAppliedAllSources = {
       ScheduleSource: 'VOD',
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE',
-      heightRatio: 0.56
+      aspectRatio: 1.78
     },
     captions: [
       {
@@ -472,7 +472,7 @@ const NoPluginsWithDrm = {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
       tags: '',
-      heightRatio: 0.57
+      aspectRatio: 1.76
     },
     progressive: [],
     dash: [
@@ -554,7 +554,7 @@ const WithPluginsNoDrm = {
       HLSOnly: 'android',
       ChannelName: 'Disney Channel SE',
       tags: '',
-      heightRatio: 0.56
+      aspectRatio: 1.78
     },
     progressive: [
       {
@@ -683,7 +683,7 @@ const WithPluginsWithDrm = {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
       tags: '',
-      heightRatio: 0.57
+      aspectRatio: 1.76
     },
     progressive: [],
     dash: [
@@ -748,7 +748,6 @@ const AudioEntryWithoutPlugins = {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
       tags: 'dual audio, english, spanish',
-      heightRatio: 1.78
     },
     progressive: [
       {
@@ -1185,7 +1184,6 @@ const EntryWithBumper = {
       tags: '',
       MediaType: 'Movie',
       WatchPermissionRule: 'Parrent Allowed',
-      heightRatio: 1.78
     },
     captions: [
       {
@@ -1304,7 +1302,6 @@ const EntryWithBumperWithKs = {
       tags: '',
       MediaType: 'Movie',
       WatchPermissionRule: 'Parrent Allowed',
-      heightRatio: 1.78
     },
     captions: [
       {
@@ -1426,7 +1423,6 @@ const EntryWithNoBumper = {
       tags: '',
       MediaType: 'Movie',
       WatchPermissionRule: 'Parrent Allowed',
-      heightRatio: 1.78
     },
     captions: [
       {
@@ -1518,7 +1514,7 @@ const EntryOfPartner0 = {
       entryId: '0_pi55vv3r',
       description: 'Titanic movie summarized in 5 seconds',
       tags: 'titanic, short',
-      heightRatio: 0.75
+      aspectRatio: 1.33
     },
     captions: [],
     downloadUrl: ''

--- a/test/src/k-provider/ovp/provider-parser-data.js
+++ b/test/src/k-provider/ovp/provider-parser-data.js
@@ -79,7 +79,6 @@ const youtubeMediaEntryResult = {
     description: 'youtube description',
     name: 'test youtube entry',
     tags: '',
-    heightRatio: 1.78,
   },
   type: 'Unknown',
   poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001',


### PR DESCRIPTION
### Description of the Changes

Changes since [previous PR](https://github.com/kaltura/playkit-js-providers/pull/239):
- Rename to aspectRatio, which is the standard name
- Divide width by height and not vice versa
- Remove the default value
- Fix unit tests

Why we don't want to set a default value:
- Default value was set when context / height / width were not set. This happened when fetching the partial sources data for playlist.
- Meaning, the partial source of an entry in playlist always had an INITIAL value of aspectRatio = 1.78
- When loadMedia was called, this code was called again, with context this time, and it returned a source with the CORRECT value of aspectRatio
- The player would then try to merge the two sources objects (partial and full), but because the initial aspectRatio was already set - the correct value did not override the initial value, since it would only override values which are not yet set.
- This caused the entry aspectRatio to have an incorrect value.

Resolves FEC-14047