### PR TITLE
fix(FEC-14049): Send referrer only if it came from iFrame embed

### DIFF
--- a/src/k-provider/ovp/services/base-entry-service.ts
+++ b/src/k-provider/ovp/services/base-entry-service.ts
@@ -23,7 +23,10 @@ export default class OVPBaseEntryService extends OVPService {
     request.method = 'POST';
     request.url = request.getUrl(serviceUrl);
     request.tag = 'baseEntry-getPlaybackContext';
-    const contextDataParams = {objectType: 'KalturaContextDataParams', flavorTags: 'all', referrer};
+    const contextDataParams = {objectType: 'KalturaContextDataParams', flavorTags: 'all'};
+    if (referrer) {
+      contextDataParams['referrer'] = referrer;
+    }
     request.params = {entryId: serviceEntryId, ks: ks, contextDataParams: contextDataParams};
     return request;
   }


### PR DESCRIPTION
### Description of the Changes

In case of iframe embed, the BE adds a parameter to the bundle window.originalRequestReferrer, this value will be added to api calls from the player to the backend for evaluation of access control request.
If the PR is related to an open issue please link to it.

Issue:
The decision when to send it with API calls to the backend needs to be based if it was supplied in origin

Fix:
Send the referrer to the provider only if it was supplied by the backend

Resolves FEC-[https://kaltura.atlassian.net/browse/[FEC-14049](https://kaltura.atlassian.net/browse/FEC-14049)]


[FEC-14049]: https://kaltura.atlassian.net/browse/FEC-14049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ