### PR TITLE
fix(FEC-14071): thumbnail requests append height, width, ks too many times

### DIFF
--- a/src/entities/media-entry.ts
+++ b/src/entities/media-entry.ts
@@ -75,6 +75,12 @@ export default class MediaEntry {
   public downloadUrl?: string;
 
   /**
+   * @member - The raw thumbnail URL
+   * @type {string}
+   */
+  public rawThumbnailUrl?: string;
+
+  /**
    * @constructor
    */
   constructor() {
@@ -99,7 +105,8 @@ export default class MediaEntry {
       type: this.type,
       poster: this.poster,
       assetReferenceType: this.assetReferenceType,
-      downloadUrl: this.downloadUrl
+      downloadUrl: this.downloadUrl,
+      rawThumbnailUrl: this.rawThumbnailUrl
     };
   }
 }

--- a/src/k-provider/ovp/provider-parser.ts
+++ b/src/k-provider/ovp/provider-parser.ts
@@ -153,6 +153,7 @@ class OVPProviderParser {
 
   private static _fillBaseData(mediaEntry: MediaEntry, entry: KalturaMediaEntry, metadataList?: KalturaMetadataListResponse, playbackContext?: any): MediaEntry {
     mediaEntry.poster = entry.poster;
+    mediaEntry.rawThumbnailUrl = entry.rawThumbnailUrl;
     mediaEntry.id = entry.id;
     mediaEntry.duration = entry.duration;
     mediaEntry.downloadUrl = entry.downloadUrl || '';

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -326,6 +326,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
       duration: 0,
       type: MediaEntry.Type.UNKNOWN,
       poster: '',
+      rawThumbnailUrl: '',
       dvr: false,
       vr: null,
       metadata: {
@@ -349,6 +350,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     sourcesObject.type = mediaEntry.type;
     sourcesObject.dvr = !!mediaEntry.dvrStatus;
     sourcesObject.poster = mediaEntry.poster;
+    sourcesObject.rawThumbnailUrl = mediaEntry.rawThumbnailUrl;
     sourcesObject.downloadUrl = mediaEntry.downloadUrl;
     if (mediaEntry.sources.captions) {
       sourcesObject.captions = mediaEntry.sources.captions;

--- a/src/k-provider/ovp/response-types/kaltura-media-entry.ts
+++ b/src/k-provider/ovp/response-types/kaltura-media-entry.ts
@@ -181,6 +181,7 @@ export class KalturaMediaEntry {
     this.flavorParamsIds = entry.flavorParamsIds;
     this.duration = entry.duration;
     this.poster = entry.thumbnailUrl;
+    this.rawThumbnailUrl = entry.thumbnailUrl;
     this.status = entry.status;
     this.dvrStatus = entry.dvrStatus;
     this.tags = entry.tags;
@@ -191,6 +192,5 @@ export class KalturaMediaEntry {
     this.plays = entry.plays;
     this.views = entry.views;
     this.downloadUrl = entry.downloadUrl;
-    this.rawThumbnailUrl = entry.thumbnailUrl;
   }
 }

--- a/src/k-provider/ovp/response-types/kaltura-media-entry.ts
+++ b/src/k-provider/ovp/response-types/kaltura-media-entry.ts
@@ -160,6 +160,12 @@ export class KalturaMediaEntry {
   public creatorId: string;
 
   /**
+   * @member - The raw thumbnail URL
+   * @type {string}
+   */
+  public rawThumbnailUrl: string;
+
+  /**
    * @constructor
    * @param {Object} entry The json response
    */
@@ -185,5 +191,6 @@ export class KalturaMediaEntry {
     this.plays = entry.plays;
     this.views = entry.views;
     this.downloadUrl = entry.downloadUrl;
+    this.rawThumbnailUrl = entry.thumbnailUrl;
   }
 }

--- a/src/types/media-config-sources.ts
+++ b/src/types/media-config-sources.ts
@@ -19,4 +19,5 @@ export type ProviderMediaConfigSourcesObject = {
   metadata: ProviderMediaConfigMetadataObject;
   captions?: Array<PKExternalCaptionObject>;
   downloadUrl?: string;
+  rawThumbnailUrl?: string;
 };

--- a/src/types/media-entry.ts
+++ b/src/types/media-entry.ts
@@ -13,4 +13,5 @@ export type ProviderMediaEntryObject = {
   poster?: string | Poster[];
   downloadUrl?: string;
   assetReferenceType?: string;
+  rawThumbnailUrl?: string;
 };

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -13,6 +13,7 @@ const NoPluginsNoDrm = {
     vr: null,
     type: 'Vod',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '1_rsrdfext',
       name: 'FO21934-HDTX-SWE',
@@ -266,6 +267,7 @@ const RegexAppliedPlayManifestSources = {
     duration: 55,
     type: 'Vod',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     dvr: false,
     vr: null,
     metadata: {
@@ -412,6 +414,7 @@ const RegexAppliedAllSources = {
     type: 'Vod',
     poster:
       'http://qa-kes-ebu-01.dev.kaltura.com/kAPI/kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     dvr: false,
     vr: null,
     metadata: {
@@ -466,6 +469,7 @@ const NoPluginsWithDrm = {
     vr: null,
     type: 'Vod',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '1_rwbj3j0a',
       name: 'DRM TEST',
@@ -532,6 +536,7 @@ const WithPluginsNoDrm = {
     vr: null,
     type: 'Vod',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '1_rsrdfext',
       name: 'FO21934-HDTX-SWE',
@@ -677,6 +682,7 @@ const WithPluginsWithDrm = {
     vr: null,
     type: 'Vod',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '1_rwbj3j0a',
       name: 'DRM TEST',
@@ -742,6 +748,7 @@ const AudioEntryWithoutPlugins = {
     vr: null,
     type: 'Audio',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '0_vyzw3ceu',
       name: 'TEST_WAESP_PLACINGTEST_DUAL',
@@ -805,6 +812,7 @@ const ImageEntryWithoutPlugins = {
     vr: null,
     type: 'Image',
     poster: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
+    rawThumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
     metadata: {
       entryId: '0_84zz779s',
       name: 'Channel HU-TEST-STG-Attila-160203 Thumbnail',
@@ -1175,6 +1183,7 @@ const EntryWithBumper = {
     duration: 741,
     type: 'Vod',
     poster: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
+    rawThumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
     dvr: false,
     vr: null,
     metadata: {
@@ -1293,6 +1302,7 @@ const EntryWithBumperWithKs = {
     duration: 741,
     type: 'Vod',
     poster: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
+    rawThumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
     dvr: false,
     vr: null,
     metadata: {
@@ -1414,6 +1424,7 @@ const EntryWithNoBumper = {
     duration: 741,
     type: 'Vod',
     poster: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
+    rawThumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
     dvr: false,
     vr: null,
     metadata: {
@@ -1507,6 +1518,7 @@ const EntryOfPartner0 = {
     duration: 11,
     type: 'Vod',
     poster: 'https://cfvod.kaltura.com/p/1645161/sp/164516100/thumbnail/entry_id/0_pi55vv3r/version/100002',
+    rawThumbnailUrl: 'https://cfvod.kaltura.com/p/1645161/sp/164516100/thumbnail/entry_id/0_pi55vv3r/version/100002',
     dvr: false,
     vr: null,
     metadata: {


### PR DESCRIPTION
### Description of the Changes

bugfix

**Issue:**
when building `poster` and `sprite` URLs, we are using the `poster` as the base url and then appending params to it (height, width, ks). But, when `poster` has already been manipulated and we try to build it again, we re-append the params.

**Fix:**
add a new field to the media config sources object, named `rawThumbnailUrl` which holds the raw url and can be used as the base url when building `poster` and `sprite`, instead of using the (manipulated) `poster`.

related PR: https://github.com/kaltura/kaltura-player-js/pull/830

#### Resolves FEC-14071
