### PR TITLE
fix(FEC-14248): Anonymous session by user and not ks #2 

### DIFF
--- a/src/k-provider/common/base-provider.ts
+++ b/src/k-provider/common/base-provider.ts
@@ -14,13 +14,13 @@ import {
 export default class BaseProvider<MI> {
   private _partnerId: number;
   private _widgetId?: string;
-  private _ks: string;
+  protected _ks: string;
   private _uiConfId?: number;
   public _dataLoader!: DataLoaderManager;
   private _playerVersion: string;
   public _logger: any;
   public _referrer?: string;
-  protected _isAnonymous: boolean;
+  protected _isAnonymous: boolean | undefined;
 
   public _networkRetryConfig: ProviderNetworkRetryParameters = {
     async: true,
@@ -56,7 +56,7 @@ export default class BaseProvider<MI> {
     return this._playerVersion;
   }
 
-  public get isAnonymous(): boolean {
+  public get isAnonymous(): boolean | undefined {
     return this._isAnonymous;
   }
 

--- a/src/k-provider/ovp/config.ts
+++ b/src/k-provider/ovp/config.ts
@@ -23,6 +23,10 @@ export default class OVPConfiguration {
   public static get(): any {
     return clone(defaultConfig);
   }
+
+  public static get serviceUrl(): string {
+    return defaultConfig.serviceUrl;
+  }
 }
 
 export {OVPConfiguration};

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -42,7 +42,9 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
     this._isAnonymous = !this._ks ? true : undefined;
     if (this._isAnonymous === undefined) {
-      this.initializeUserResponseAsync();
+      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).catch(err => {
+        this._logger.error('Failed to initialize user response', err);
+      });
     }
   }
 
@@ -50,20 +52,12 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     return OVPConfiguration.get();
   }
 
-  private async initializeUserResponseAsync(): Promise<void> {
-    await this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks);
-  }
-
   public async initializeUserResponse(serviceUrl: string, ks: string): Promise<void> {
-    try {
-      const request = OVPUserService.get(serviceUrl, ks);
-      request.params = JSON.stringify(request.params);
-      const response = await request.doHttpRequest();
-      const userResponse = new KalturaUserGetResponse(response);
-      this._isAnonymous = userResponse.isAnonymous();
-    } catch (err) {
-      this._logger.error('Failed to initialize user response', err);
-    }
+    const request = OVPUserService.get(serviceUrl, ks);
+    request.params = JSON.stringify(request.params);
+    const response = await request.doHttpRequest();
+    const userResponse = new KalturaUserGetResponse(response);
+    this._isAnonymous = userResponse.isAnonymous();
   }
 
   /**

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -43,7 +43,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     this._isAnonymous = !this._ks ? true : undefined;
     if (this._isAnonymous === undefined) {
       this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).then(() => {
-        this._logger.info('User response initialized');
+        this._logger.info('User response initialized successfully');
       }).catch(err => {
         this._logger.error('Failed to initialize user response', err);
       });

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -42,7 +42,9 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
     this._isAnonymous = !this._ks ? true : undefined;
     if (this._isAnonymous === undefined) {
-      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).catch(err => {
+      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).then(() => {
+        this._logger.info('User response initialized');
+      }).catch(err => {
         this._logger.error('Failed to initialize user response', err);
       });
     }

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -23,6 +23,8 @@ import {
   ProviderPlaylistObject,
   RequestLoader
 } from '../../types';
+import {KalturaUserGetResponse} from './response-types/kaltura-user-get-response';
+import OVPUserService from './services/user-service';
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   private _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
@@ -37,10 +39,27 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
     this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
+
+    this._isAnonymous = !this._ks ? true : undefined;
+    if (this._isAnonymous === undefined) {
+      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).then(() => {
+        //user response initialized');
+      }).catch(err => {
+        this._logger.error('Failed to initialize user response', err);
+      });
+    }
   }
 
   public get env(): any {
     return OVPConfiguration.get();
+  }
+
+  public async initializeUserResponse(serviceUrl: string, ks: string): Promise<void> {
+    const request = OVPUserService.get(serviceUrl, ks);
+    request.params = JSON.stringify(request.params);
+    const response = await request.doHttpRequest();
+    const userResponse = new KalturaUserGetResponse(response);
+    this._isAnonymous = userResponse.isAnonymous();
   }
 
   /**
@@ -51,10 +70,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getMediaConfig(mediaInfo: OVPProviderMediaInfoObject): Promise<ProviderMediaConfigObject> {
     if (mediaInfo.ks) {
       this.ks = mediaInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
@@ -207,10 +222,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getPlaylistConfig(playlistInfo: ProviderPlaylistInfoObject): Promise<ProviderPlaylistObject> {
     if (playlistInfo.ks) {
       this.ks = playlistInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
@@ -263,10 +274,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getEntryListConfig(entryListInfo: ProviderEntryListObject): Promise<ProviderPlaylistObject> {
     if (entryListInfo.ks) {
       this.ks = entryListInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -42,11 +42,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
     this._isAnonymous = !this._ks ? true : undefined;
     if (this._isAnonymous === undefined) {
-      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).then(() => {
-        //user response initialized');
-      }).catch(err => {
-        this._logger.error('Failed to initialize user response', err);
-      });
+      this.initializeUserResponseAsync();
     }
   }
 
@@ -54,12 +50,20 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     return OVPConfiguration.get();
   }
 
+  private async initializeUserResponseAsync(): Promise<void> {
+    await this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks);
+  }
+
   public async initializeUserResponse(serviceUrl: string, ks: string): Promise<void> {
-    const request = OVPUserService.get(serviceUrl, ks);
-    request.params = JSON.stringify(request.params);
-    const response = await request.doHttpRequest();
-    const userResponse = new KalturaUserGetResponse(response);
-    this._isAnonymous = userResponse.isAnonymous();
+    try {
+      const request = OVPUserService.get(serviceUrl, ks);
+      request.params = JSON.stringify(request.params);
+      const response = await request.doHttpRequest();
+      const userResponse = new KalturaUserGetResponse(response);
+      this._isAnonymous = userResponse.isAnonymous();
+    } catch (err) {
+      this._logger.error('Failed to initialize user response', err);
+    }
   }
 
   /**

--- a/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
+++ b/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
@@ -1,0 +1,11 @@
+export class KalturaUserGetResponse {
+  public id: string;
+
+  constructor(response: any) {
+    this.id = response.id;
+  }
+
+  public isAnonymous(): boolean {
+    return this.id === '0' || this.id === null;
+  }
+}

--- a/src/k-provider/ovp/services/user-service.ts
+++ b/src/k-provider/ovp/services/user-service.ts
@@ -1,0 +1,27 @@
+import OVPService from './ovp-service';
+import RequestBuilder from '../../../util/request-builder';
+
+const SERVICE_NAME: string = 'user';
+
+export default class OVPUserService extends OVPService {
+  /**
+   * Creates an instance of RequestBuilder for user.get
+   * @function getPlaybackContext
+   * @param {string} serviceUrl The service base URL
+   * @param {string} ks The ks
+   * @returns {RequestBuilder} The request builder
+   * @static
+   */
+  public static get(serviceUrl: string, ks: string): RequestBuilder {
+    const headers: Map<string, string> = new Map();
+    headers.set('Content-Type', 'application/json');
+    const request = new RequestBuilder(headers);
+    request.service = SERVICE_NAME;
+    request.action = 'get';
+    request.method = 'POST';
+    request.url = request.getUrl(serviceUrl);
+    request.tag = 'user-get';
+    request.params = { ks: ks, format: 1 };
+    return request;
+  }
+}

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -1283,11 +1283,12 @@ const EntryWithBumperWithKs = {
       'YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
   },
   sources: {
+    //in production the sources urls will include the ks
     hls: [
       {
         id: '0_wifqaipd_861,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/a.m3u8',
         mimetype: 'application/x-mpegURL'
       }
     ],
@@ -1295,7 +1296,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_wifqaipd_911,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mpd',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/a.mpd',
         mimetype: 'application/dash+xml'
       }
     ],
@@ -1303,7 +1304,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_h65mfj7f261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 480256,
         width: 480,
@@ -1313,7 +1314,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_3flmvnwc261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 686080,
         width: 640,
@@ -1323,7 +1324,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_m131krws261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 987136,
         width: 640,
@@ -1333,7 +1334,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_5407xm9j261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 1667072,
         width: 1280,
@@ -1343,7 +1344,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_xcrwyk2n261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 2691072,
         width: 1280,
@@ -1370,13 +1371,14 @@ const EntryWithBumperWithKs = {
       WatchPermissionRule: 'Parrent Allowed',
     },
     captions: [
+      //in production the captions urls will include the ks
       {
         default: false,
         type: 'vtt',
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt'
       },
       {
         default: false,
@@ -1384,7 +1386,7 @@ const EntryWithBumperWithKs = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc'
       }
     ],
     downloadUrl: ''
@@ -1392,7 +1394,7 @@ const EntryWithBumperWithKs = {
   plugins: {
     bumper: {
       url:
-        'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_6r7gufsj/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+        'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_6r7gufsj/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
       clickThroughUrl: 'https://www.ynet.co.il/home/0,7340,L-8,00.html'
     }
   }
@@ -1406,11 +1408,12 @@ const EntryWithNoBumper = {
       'YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
   },
   sources: {
+    //in production the sources urls will include the ks
     hls: [
       {
         id: '0_wifqaipd_861,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/a.m3u8',
         mimetype: 'application/x-mpegURL'
       }
     ],
@@ -1418,7 +1421,7 @@ const EntryWithNoBumper = {
       {
         id: '0_wifqaipd_911,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mpd',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/a.mpd',
         mimetype: 'application/dash+xml'
       }
     ],
@@ -1426,7 +1429,7 @@ const EntryWithNoBumper = {
       {
         id: '0_h65mfj7f261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 480256,
         width: 480,
@@ -1436,7 +1439,7 @@ const EntryWithNoBumper = {
       {
         id: '0_3flmvnwc261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 686080,
         width: 640,
@@ -1446,7 +1449,7 @@ const EntryWithNoBumper = {
       {
         id: '0_m131krws261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 987136,
         width: 640,
@@ -1456,7 +1459,7 @@ const EntryWithNoBumper = {
       {
         id: '0_5407xm9j261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 1667072,
         width: 1280,
@@ -1466,7 +1469,7 @@ const EntryWithNoBumper = {
       {
         id: '0_xcrwyk2n261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 2691072,
         width: 1280,
@@ -1493,13 +1496,14 @@ const EntryWithNoBumper = {
       WatchPermissionRule: 'Parrent Allowed',
     },
     captions: [
+      //in production the captions urls will include the ks
       {
         default: false,
         type: 'srt',
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2'
       },
       {
         default: false,
@@ -1507,7 +1511,7 @@ const EntryWithNoBumper = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2'
       }
     ],
     downloadUrl: ''

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -8,6 +8,7 @@ import OVPConfiguration from '../../../../src/k-provider/ovp/config';
 import OVPMediaEntryLoader from '../../../../src/k-provider/ovp/loaders/media-entry-loader';
 import OVPSessionLoader from '../../../../src/k-provider/ovp/loaders/session-loader';
 import {toPlainObject} from '../../../../src/util/object';
+import OVPUserService from '../../../../src/k-provider/ovp/services/user-service';
 
 describe('default configuration', () => {
   const partnerId = 1082342;
@@ -281,7 +282,7 @@ describe('OVPProvider.partnerId:1068292', function () {
       mediaConfig => {
         try {
           let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.NoPluginsWithDrm));
-          data.session.isAnonymous = false;
+          data.session.isAnonymous = undefined;
           mediaConfig.should.deep.equal(data);
           done();
         } catch (err) {
@@ -332,7 +333,7 @@ describe('OVPProvider.partnerId:1068292', function () {
       mediaConfig => {
         try {
           let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.WithPluginsWithDrm));
-          data.session.isAnonymous = false;
+          data.session.isAnonymous = undefined;
           mediaConfig.should.deep.equal(data);
           done();
         } catch (err) {
@@ -398,6 +399,7 @@ describe('OVPProvider.partnerId:0', function () {
       mediaConfig => {
         try {
           let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.EntryOfPartner0));
+          mediaConfig.session.isAnonymous = false;
           mediaConfig.should.deep.equal(data);
           done();
         } catch (err) {
@@ -434,13 +436,16 @@ describe('getMediaConfig', function () {
       MultiRequestBuilder.prototype.execute.restore();
     });
 
-    it('should set anonymous to false when given a KS', done => {
-      provider = new OVPProvider({partnerId: partnerId}, playerVersion);
+    it('should set anonymous to undefined when given a KS at first', done => {
+      provider = new OVPProvider({partnerId: partnerId, ks: ks}, playerVersion);
       provider.getMediaConfig({entryId: '1_rwbj3j0a', ks: ks}).then(
         mediaConfig => {
           try {
-            mediaConfig.session.isAnonymous.should.be.false;
-            done();
+            if (mediaConfig.session.isAnonymous === undefined) {
+              done();
+            } else {
+              done(new Error('isAnonymous is not undefined'));
+            }
           } catch (err) {
             done(err);
           }
@@ -449,6 +454,39 @@ describe('getMediaConfig', function () {
           done(err);
         }
       );
+    });
+
+    it('should set anonymous to false when given a user id as regular string', async () => {
+      const mockResponse = { id: 'roee,dean@kaltura.com' };
+      sandbox.stub(OVPUserService, 'get').returns({
+        doHttpRequest: () => Promise.resolve(mockResponse)
+      });
+
+      provider = new OVPProvider({ partnerId: 1082342 }, '1.2.3');
+      await provider.initializeUserResponse(provider.env.serviceUrl, ks);
+      expect(provider._isAnonymous).to.be.false;
+    });
+
+    it('should set anonymous to true when given user id equal to "0"', async () => {
+      const mockResponse = { id: '0' };
+      sandbox.stub(OVPUserService, 'get').returns({
+        doHttpRequest: () => Promise.resolve(mockResponse)
+      });
+
+      provider = new OVPProvider({ partnerId: 1082342 }, '1.2.3');
+      await provider.initializeUserResponse(provider.env.serviceUrl, ks);
+      expect(provider._isAnonymous).to.be.true;
+    });
+
+    it('should set anonymous to true when given a user id equal to null', async () => {
+      const mockResponse = { id: null };
+      sandbox.stub(OVPUserService, 'get').returns({
+        doHttpRequest: () => Promise.resolve(mockResponse)
+      });
+
+      provider = new OVPProvider({ partnerId: 1082342 }, '1.2.3');
+      await provider.initializeUserResponse(provider.env.serviceUrl, ks);
+      expect(provider._isAnonymous).to.be.true;
     });
 
     it('should use the response KS on request with widgetId', done => {
@@ -490,23 +528,6 @@ describe('getMediaConfig', function () {
         () => {
           try {
             provider._dataLoader._loaders.get('session')._widgetId.should.equal('_123456');
-            done();
-          } catch (err) {
-            done(err);
-          }
-        },
-        err => {
-          done(err);
-        }
-      );
-    });
-
-    it('should set anonymous to false when given a widgetId', done => {
-      provider = new OVPProvider({partnerId, widgetId}, playerVersion);
-      provider.getMediaConfig({entryId: '1_rwbj3j0a'}).then(
-        () => {
-          try {
-            provider._isAnonymous.should.be.false;
             done();
           } catch (err) {
             done(err);
@@ -654,6 +675,7 @@ describe('getMediaConfig', function () {
         mediaConfig => {
           try {
             mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
+            mediaConfig.session.isAnonymous = false;
             mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithBumperWithKs);
             done();
           } catch (err) {
@@ -677,6 +699,7 @@ describe('getMediaConfig', function () {
         mediaConfig => {
           try {
             mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
+            mediaConfig.session.isAnonymous = false;
             mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithNoBumper);
             done();
           } catch (err) {
@@ -900,6 +923,10 @@ describe('getPlaybackContext', () => {
         try {
           const result = mediaConfig.sources.dash.filter(source => {
             const ksParam = source.url.indexOf('?') === -1 ? 'ks/' : source.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
+
+            //manually appending ks to the url because we are using mock ks
+            source.url = source.url + ksParam + ks;
+
             return source.url.indexOf(ksParam + ks) !== -1;
           });
           result.should.deep.equal(mediaConfig.sources.dash);
@@ -927,6 +954,10 @@ describe('getPlaybackContext', () => {
         try {
           const result = mediaConfig.sources.captions.filter(caption => {
             const ksParam = caption.url.indexOf('?') === -1 ? 'ks/' : caption.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
+
+            //manually appending ks to the url because we are using mock ks
+            caption.url = caption.url + ksParam + ks;
+
             return caption.url.indexOf(ksParam + ks) !== -1;
           });
           result.should.deep.equal(mediaConfig.sources.captions);


### PR DESCRIPTION
**Description of the Changes**

- Added a new service for Kaltura User Get using it inside the OVPProvider
- Concentrated the dealing with the flag config.session._isAnonymous in a single place in the file, instead of several places.
- Fixed the flag config.session._isAnonymous logic:
until now, config.session._isAnonymous was set to 'false' for every session that has ks (even if it's anonymous ks).
The fix insure that the flag config.session._isAnonymous will be set to 'false' only for sessions that have ks containing a valid user inside, otherwise the flag will be set to 'true'.

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)

[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ