### PR TITLE
fix(FEC-14248): Anonymous session by user and not ks + remarks

### DIFF
--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -42,7 +42,9 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
 
     this._isAnonymous = !this._ks ? true : undefined;
     if (this._isAnonymous === undefined) {
-      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).catch(err => {
+      this.initializeUserResponse(OVPConfiguration.serviceUrl, this._ks).then(() => {
+        this._logger.info('User response initialized');
+      }).catch(err => {
         this._logger.error('Failed to initialize user response', err);
       });
     }


### PR DESCRIPTION
**Description of the Changes**

- Added a new service for Kaltura User Get using it inside the OVPProvider.
- Concentrated the dealing with the flag config.session._isAnonymous in a single place in the file, instead of several places.
- Fixed the flag config.session._isAnonymous logic:
until now, config.session._isAnonymous was set to 'false' for every session that has ks (even if it's anonymous ks).
The fix insure that the flag config.session._isAnonymous will be set to 'false' only for sessions that have ks containing a valid user inside, otherwise the flag will be set to 'true'.

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)

[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ