### PR TITLE
SUP-46065: Player shows VR button based on "360" (or variations) tag

### DIFF
--- a/src/k-provider/common/base-provider.ts
+++ b/src/k-provider/common/base-provider.ts
@@ -21,6 +21,7 @@ export default class BaseProvider<MI> {
   public _logger: any;
   public _referrer?: string;
   protected _isAnonymous: boolean;
+  public vrTag?: string;
 
   public _networkRetryConfig: ProviderNetworkRetryParameters = {
     async: true,
@@ -60,7 +61,7 @@ export default class BaseProvider<MI> {
     return this._isAnonymous;
   }
 
-  constructor(options: ProviderOptionsObject, playerVersion: string) {
+  constructor(options: ProviderOptionsObject, playerVersion: string, vrTag?: string) {
     setLogger(options.logger);
     this._partnerId = options.partnerId;
     this._widgetId = options.widgetId;
@@ -69,6 +70,7 @@ export default class BaseProvider<MI> {
     this._ks = options.ks || '';
     this._playerVersion = playerVersion;
     this._referrer = options.referrer;
+    this.vrTag = vrTag;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -30,9 +30,10 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
    * @param {string} playerVersion - player version
+   * @param {vrTag} - vr tag if exist
    */
-  constructor(options: ProviderOptionsObject, playerVersion: string) {
-    super(options, playerVersion);
+  constructor(options: ProviderOptionsObject, playerVersion: string, vrTag?: string) {
+    super(options, playerVersion, vrTag);
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
@@ -360,7 +361,8 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (mediaEntry.sources.captions) {
       sourcesObject.captions = mediaEntry.sources.captions;
     }
-    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.split(', ').includes('360')) {
+
+    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.split(', ').includes(this.vrTag)) {
       sourcesObject.vr = {};
     }
     Object.assign(sourcesObject.metadata, mediaEntry.metadata);


### PR DESCRIPTION
issue:
360 tag is being concat and playing 360VR video when no needed.

fix:
support new feature: add to the configuration a tag in the vr plugin, and compare it to the metadata tags of the entry.
pass it through the provider because it has now access to the UIConf.

solved:
[SUP-46065](https://kaltura.atlassian.net/browse/SUP-46065)