### PR TITLE
fix(SUP-46065): Player shows VR button based on "360" (or variations) tag

### DIFF
--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -26,6 +26,7 @@ import {
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   private _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
+  private _vrTag: string;
   /**
    * @constructor
    * @param {ProviderOptionsObject} options - provider options
@@ -36,6 +37,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
+    this._vrTag = options.vrTag ?? '360';
     this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
   }
 
@@ -360,9 +362,10 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     if (mediaEntry.sources.captions) {
       sourcesObject.captions = mediaEntry.sources.captions;
     }
-    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.split(', ').includes('360')) {
+    if (mediaEntry.metadata && typeof mediaEntry.metadata.tags === 'string' && mediaEntry.metadata.tags.split(',').some(tag => tag.trim() === this._vrTag)) {
       sourcesObject.vr = {};
     }
+
     Object.assign(sourcesObject.metadata, mediaEntry.metadata);
     return sourcesObject;
   }

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -37,7 +37,7 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     this._logger = getLogger('OVPProvider');
     OVPConfiguration.set(options.env);
     this._setFilterOptionsConfig(options.filterOptions);
-    this._vrTag = options.vrTag ?? '360';
+    this._vrTag = options.vrTag || '360';
     this._networkRetryConfig = Object.assign(this._networkRetryConfig, options.networkRetryParameters);
   }
 

--- a/src/types/provider-options.ts
+++ b/src/types/provider-options.ts
@@ -15,4 +15,5 @@ export type ProviderOptionsObject = {
   ignoreServerConfig?: boolean;
   loadThumbnailWithKs?: boolean;
   referrer?: string;
+  vrTag?: string;
 };


### PR DESCRIPTION
**Issue:**
360 tag is being concat and playing 360VR video when no needed.

**Fix:**
Support new feature: Support a new configuration provider a new field of vrTag for custom tag.
Instead of compare the tags in the metadata to '360', compare it to the vrTag.

solved:
[SUP-46065](https://kaltura.atlassian.net/browse/SUP-46065)

[SUP-46065]: https://kaltura.atlassian.net/browse/SUP-46065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ