### PR TITLE
fix(FEC-14248): Anonymous session based on if ks contain user

### DIFF
--- a/src/k-provider/ovp/loaders/media-entry-loader.ts
+++ b/src/k-provider/ovp/loaders/media-entry-loader.ts
@@ -52,7 +52,9 @@ export default class OVPMediaEntryLoader implements ILoader {
     this._response.entry = mediaEntryResponse.entries[0];
     this._response.playBackContextResult = new KalturaPlaybackContext(response[1].data);
     this._response.metadataListResult = new KalturaMetadataListResponse(response[2].data);
-    this._response.userGetResult = new KalturaUserGetResponse(response[3].data);
+    if (response[3]) {
+      this._response.userGetResult = new KalturaUserGetResponse(response[3].data);
+    }
   }
 
   public get response(): OVPMediaEntryLoaderResponse {
@@ -74,7 +76,9 @@ export default class OVPMediaEntryLoader implements ILoader {
     const serviceEntryId = params.ks === '{1:result:ks}' ? '{2:result:objects:0:id}' : '{1:result:objects:0:id}';
     requests.push(OVPBaseEntryService.getPlaybackContext(config.serviceUrl, params.ks, serviceEntryId, params.referrer));
     requests.push(OVPMetadataService.list(config.serviceUrl, params.ks, serviceEntryId));
-    requests.push(OVPUserService.get(config.serviceUrl, params.ks));
+    if (params.ks !== '{1:result:ks}') {
+      requests.push(OVPUserService.get(config.serviceUrl, params.ks));
+    }
     return requests;
   }
 

--- a/src/k-provider/ovp/loaders/media-entry-loader.ts
+++ b/src/k-provider/ovp/loaders/media-entry-loader.ts
@@ -7,11 +7,14 @@ import {KalturaMetadataListResponse} from '../response-types';
 import {KalturaBaseEntryListResponse} from '../response-types';
 import {KalturaMediaEntry} from '../response-types';
 import {ILoader} from '../../../types';
+import OVPUserService from '../services/user-service';
+import {KalturaUserGetResponse} from '../response-types/kaltura-user-get-response';
 
 type OVPMediaEntryLoaderResponse = {
   entry: KalturaMediaEntry;
   playBackContextResult: KalturaPlaybackContext;
   metadataListResult: KalturaMetadataListResponse;
+  userGetResult: KalturaUserGetResponse;
 };
 export type {OVPMediaEntryLoaderResponse};
 
@@ -49,6 +52,7 @@ export default class OVPMediaEntryLoader implements ILoader {
     this._response.entry = mediaEntryResponse.entries[0];
     this._response.playBackContextResult = new KalturaPlaybackContext(response[1].data);
     this._response.metadataListResult = new KalturaMetadataListResponse(response[2].data);
+    this._response.userGetResult = new KalturaUserGetResponse(response[3].data);
   }
 
   public get response(): OVPMediaEntryLoaderResponse {
@@ -70,6 +74,7 @@ export default class OVPMediaEntryLoader implements ILoader {
     const serviceEntryId = params.ks === '{1:result:ks}' ? '{2:result:objects:0:id}' : '{1:result:objects:0:id}';
     requests.push(OVPBaseEntryService.getPlaybackContext(config.serviceUrl, params.ks, serviceEntryId, params.referrer));
     requests.push(OVPMetadataService.list(config.serviceUrl, params.ks, serviceEntryId));
+    requests.push(OVPUserService.get(config.serviceUrl, params.ks));
     return requests;
   }
 

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -68,10 +68,16 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         return this._dataLoader.fetchData().then(
           response => {
             try {
-              // Fetch the userGetResponse response
-              const userGetResponse = response.get(OVPMediaEntryLoader.id).response.userGetResult;
-              // Set isAnonymous
-              this._isAnonymous = userGetResponse.isAnonymous();
+              const mediaEntryLoaderResponse = response.get(OVPMediaEntryLoader.id);
+              if (mediaEntryLoaderResponse?.response?.userGetResult) {
+                // Fetch the userGetResponse response
+                const userGetResponse = new KalturaUserGetResponse(mediaEntryLoaderResponse.response.userGetResult);
+                // Set isAnonymous
+                this._isAnonymous = userGetResponse?.isAnonymous();
+              }
+              else {
+                this._isAnonymous = true;
+              }
               const mediaConfig = this._parseDataFromResponse(response);
               RegexActionHandler.handleRegexAction(mediaConfig, response).then(resolve);
             } catch (err) {

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -23,6 +23,7 @@ import {
   ProviderPlaylistObject,
   RequestLoader
 } from '../../types';
+import {KalturaUserGetResponse} from './response-types/kaltura-user-get-response';
 
 export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject> {
   private _filterOptionsConfig: ProviderFilterOptionsObject = {redirectFromEntryId: true};
@@ -51,10 +52,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getMediaConfig(mediaInfo: OVPProviderMediaInfoObject): Promise<ProviderMediaConfigObject> {
     if (mediaInfo.ks) {
       this.ks = mediaInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
@@ -71,6 +68,10 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
         return this._dataLoader.fetchData().then(
           response => {
             try {
+              // Fetch the userGetResponse response
+              const userGetResponse = response.get(OVPMediaEntryLoader.id).response.userGetResult;
+              // Set isAnonymous
+              this._isAnonymous = userGetResponse.isAnonymous();
               const mediaConfig = this._parseDataFromResponse(response);
               RegexActionHandler.handleRegexAction(mediaConfig, response).then(resolve);
             } catch (err) {
@@ -207,10 +208,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getPlaylistConfig(playlistInfo: ProviderPlaylistInfoObject): Promise<ProviderPlaylistObject> {
     if (playlistInfo.ks) {
       this.ks = playlistInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {
@@ -263,10 +260,6 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
   public getEntryListConfig(entryListInfo: ProviderEntryListObject): Promise<ProviderPlaylistObject> {
     if (entryListInfo.ks) {
       this.ks = entryListInfo.ks;
-      this._isAnonymous = false;
-    }
-    if (this.widgetId !== this.defaultWidgetId) {
-      this._isAnonymous = false;
     }
     this._dataLoader = new OVPDataLoaderManager(this.playerVersion, this.partnerId, this.ks, this._networkRetryConfig);
     return new Promise((resolve, reject) => {

--- a/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
+++ b/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
@@ -1,0 +1,12 @@
+export class KalturaUserGetResponse {
+  public id: string;
+  private static readonly INVALID_IDS = ['0', '', null];
+
+  constructor(response: any) {
+    this.id = response.id;
+  }
+
+  public isAnonymous(): boolean {
+    return KalturaUserGetResponse.INVALID_IDS.includes(this.id);
+  }
+}

--- a/src/k-provider/ovp/services/user-service.ts
+++ b/src/k-provider/ovp/services/user-service.ts
@@ -1,0 +1,27 @@
+import OVPService from './ovp-service';
+import RequestBuilder from '../../../util/request-builder';
+
+const SERVICE_NAME: string = 'user';
+
+export default class OVPUserService extends OVPService {
+  /**
+   * Creates an instance of RequestBuilder for user.get
+   * @function getPlaybackContext
+   * @param {string} serviceUrl The service base URL
+   * @param {string} ks The ks
+   * @returns {RequestBuilder} The request builder
+   * @static
+   */
+  public static get(serviceUrl: string, ks: string): RequestBuilder {
+    const headers: Map<string, string> = new Map();
+    headers.set('Content-Type', 'application/json');
+    const request = new RequestBuilder(headers);
+    request.service = SERVICE_NAME;
+    request.action = 'get';
+    request.method = 'POST';
+    request.url = request.getUrl(serviceUrl);
+    request.tag = 'user-get';
+    request.params = { ks: ks, format: 1 };
+    return request;
+  }
+}

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -534,7 +534,7 @@ const NoPluginsWithDrm = {
       {
         mimetype: 'application/dash+xml',
         url:
-          'https://cdnapisec.kaltura.com/p/1068292/sp/106829200/playManifest/entryId/1_rwbj3j0a/protocol/https/format/mpegdash/flavorIds/1_92dfyrz5,1_9dhh6m0i,1_zudouuah,1_r0wu6y77,1_oz343kla/ks/NTAwZjViZWZjY2NjNTRkNGEyMjU1MTg4OGE1NmUwNDljZWJkMzk1MXwxMDY4MjkyOzEwNjgyOTI7MTQ5MDE3NjE0NjswOzE0OTAwODk3NDYuMDIyNjswO3ZpZXc6Kix3aWRnZXQ6MTs7/a.mpd',
+          'https://cdnapisec.kaltura.com/p/1068292/sp/106829200/playManifest/entryId/1_rwbj3j0a/protocol/https/format/mpegdash/flavorIds/1_92dfyrz5,1_9dhh6m0i,1_zudouuah,1_r0wu6y77,1_oz343kla/a.mpd',
         id: '1_rwbj3j0a_11331,mpegdash',
         drmData: [
           {
@@ -554,7 +554,7 @@ const NoPluginsWithDrm = {
       {
         mimetype: 'application/x-mpegURL',
         url:
-          'https://cdnapisec.kaltura.com/p/1068292/sp/106829200/playManifest/entryId/1_rwbj3j0a/protocol/https/format/applehttp/flavorIds/1_92dfyrz5,1_9dhh6m0i,1_zudouuah,1_r0wu6y77,1_oz343kla/ks/NTAwZjViZWZjY2NjNTRkNGEyMjU1MTg4OGE1NmUwNDljZWJkMzk1MXwxMDY4MjkyOzEwNjgyOTI7MTQ5MDE3NjE0NjswOzE0OTAwODk3NDYuMDIyNjswO3ZpZXc6Kix3aWRnZXQ6MTs7/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/1068292/sp/106829200/playManifest/entryId/1_rwbj3j0a/protocol/https/format/applehttp/flavorIds/1_92dfyrz5,1_9dhh6m0i,1_zudouuah,1_r0wu6y77,1_oz343kla/a.m3u8',
         id: '1_rwbj3j0a_11311,applehttp',
         drmData: [
           {
@@ -1283,11 +1283,12 @@ const EntryWithBumperWithKs = {
       'YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
   },
   sources: {
+    //in production the sources urls will include the ks
     hls: [
       {
         id: '0_wifqaipd_861,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/a.m3u8',
         mimetype: 'application/x-mpegURL'
       }
     ],
@@ -1295,15 +1296,16 @@ const EntryWithBumperWithKs = {
       {
         id: '0_wifqaipd_911,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mpd',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/a.mpd',
         mimetype: 'application/dash+xml'
       }
     ],
     progressive: [
+      //in production the sources urls will include the ks
       {
         id: '0_h65mfj7f261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 480256,
         width: 480,
@@ -1313,7 +1315,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_3flmvnwc261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 686080,
         width: 640,
@@ -1323,7 +1325,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_m131krws261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 987136,
         width: 640,
@@ -1333,7 +1335,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_5407xm9j261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 1667072,
         width: 1280,
@@ -1343,7 +1345,7 @@ const EntryWithBumperWithKs = {
       {
         id: '0_xcrwyk2n261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 2691072,
         width: 1280,
@@ -1370,13 +1372,14 @@ const EntryWithBumperWithKs = {
       WatchPermissionRule: 'Parrent Allowed',
     },
     captions: [
+      //in production the sources urls will include the ks
       {
         default: false,
         type: 'vtt',
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt?ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_kozg4x1x/segmentIndex/-1/version/2/captions.vtt'
       },
       {
         default: false,
@@ -1384,15 +1387,16 @@ const EntryWithBumperWithKs = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc'
       }
     ],
     downloadUrl: ''
   },
   plugins: {
+    //in production the sources urls will include the ks
     bumper: {
       url:
-        'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_6r7gufsj/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+        'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_6r7gufsj/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
       clickThroughUrl: 'https://www.ynet.co.il/home/0,7340,L-8,00.html'
     }
   }
@@ -1406,11 +1410,12 @@ const EntryWithNoBumper = {
       'YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
   },
   sources: {
+    //in production the sources urls will include the ks
     hls: [
       {
         id: '0_wifqaipd_861,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/applehttp/flavorIds/0_h65mfj7f,0_3flmvnwc,0_m131krws,0_5407xm9j,0_xcrwyk2n/a.m3u8',
         mimetype: 'application/x-mpegURL'
       }
     ],
@@ -1418,7 +1423,7 @@ const EntryWithNoBumper = {
       {
         id: '0_wifqaipd_911,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mpd',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/mpegdash/flavorIds/0_m131krws,0_5407xm9j,0_xcrwyk2n/a.mpd',
         mimetype: 'application/dash+xml'
       }
     ],
@@ -1426,7 +1431,7 @@ const EntryWithNoBumper = {
       {
         id: '0_h65mfj7f261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_h65mfj7f/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 480256,
         width: 480,
@@ -1436,7 +1441,7 @@ const EntryWithNoBumper = {
       {
         id: '0_3flmvnwc261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_3flmvnwc/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 686080,
         width: 640,
@@ -1446,7 +1451,7 @@ const EntryWithNoBumper = {
       {
         id: '0_m131krws261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_m131krws/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 987136,
         width: 640,
@@ -1456,7 +1461,7 @@ const EntryWithNoBumper = {
       {
         id: '0_5407xm9j261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_5407xm9j/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 1667072,
         width: 1280,
@@ -1466,7 +1471,7 @@ const EntryWithNoBumper = {
       {
         id: '0_xcrwyk2n261,url',
         url:
-          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs/a.mp4',
+          'https://cdnapisec.kaltura.com/p/1091/sp/109100/playManifest/entryId/0_wifqaipd/protocol/https/format/url/flavorIds/0_xcrwyk2n/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 2691072,
         width: 1280,
@@ -1493,13 +1498,14 @@ const EntryWithNoBumper = {
       WatchPermissionRule: 'Parrent Allowed',
     },
     captions: [
+      //in production the sources urls will include the ks
       {
         default: false,
         type: 'srt',
         language: 'en',
         label: 'En',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_kozg4x1x/v/2'
       },
       {
         default: false,
@@ -1507,7 +1513,7 @@ const EntryWithNoBumper = {
         language: 'es',
         label: 'Esp',
         url:
-          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
+          'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2'
       }
     ],
     downloadUrl: ''
@@ -1527,19 +1533,19 @@ const EntryOfPartner0 = {
       {
         id: '0_pi55vv3r_13942,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/a.m3u8',
         mimetype: 'application/x-mpegURL'
       },
       {
         id: '0_pi55vv3r_13952,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/a.m3u8',
         mimetype: 'application/x-mpegURL'
       },
       {
         id: '0_pi55vv3r_21633,applehttp',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.m3u8',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/applehttp/flavorIds/0_6gg99kvm/a.m3u8',
         mimetype: 'application/x-mpegURL'
       }
     ],
@@ -1547,13 +1553,13 @@ const EntryOfPartner0 = {
       {
         id: '0_pi55vv3r_4662,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/mpegdash/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.mpd',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/mpegdash/flavorIds/0_6gg99kvm/a.mpd',
         mimetype: 'application/dash+xml'
       },
       {
         id: '0_pi55vv3r_12972,mpegdash',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/mpegdash/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.mpd',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/mpegdash/flavorIds/0_6gg99kvm/a.mpd',
         mimetype: 'application/dash+xml'
       }
     ],
@@ -1561,7 +1567,7 @@ const EntryOfPartner0 = {
       {
         id: '0_6gg99kvm5642,url',
         url:
-          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/url/flavorIds/0_6gg99kvm/ks/djJ8MTY0NTE2MXzvlA0ktfU5h5Q_sBfvomsONiVGDO4zRRaJHvTBmnxd9eGmGQq3yvwzedJ8elff4L85A8hbCNE5rhDZsPMqDBFT_cfr1ytLeTLyEhS_ZjyYzEpZWUxzrsXjvgiSo9np4Y9H1pH6avyV4TpknfDDX20H59wjh3QhpZRn3DLryzgoTQ/a.mp4',
+          'https://cdnapisec.kaltura.com/p/0/sp/000/playManifest/entryId/0_pi55vv3r/protocol/https/format/url/flavorIds/0_6gg99kvm/a.mp4',
         mimetype: 'video/mp4',
         bandwidth: 280576,
         width: 320,


### PR DESCRIPTION
### Description of the Changes

- Added a new service for Kaltura User Get using it inside the OVPProvider
- We send the request as part of the OVPMediaEntryLoader multi-request, only if the media came with a ks from outside
- Concentrated the dealing with the flag config.session._isAnonymous in a single place in the file, instead of several places.
- Fixed the flag config.session._isAnonymous logic:
until now, config.session._isAnonymous was set to 'false' for every session that has ks (even if it's anonymous ks).
The fix insure that the flag config.session._isAnonymous will be set to 'false' only for sessions that have ks containing a valid user inside, otherwise the flag will be set to 'true'.

Related PR: https://github.com/kaltura/kaltura-player-js/pull/916

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)

[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ