### PR TITLE
fix(FEC-14248): Anonymous session based on if ks contain user

### DIFF
--- a/src/k-provider/common/base-provider.ts
+++ b/src/k-provider/common/base-provider.ts
@@ -14,13 +14,13 @@ import {
 export default class BaseProvider<MI> {
   private _partnerId: number;
   private _widgetId?: string;
-  private _ks: string;
+  protected _ks: string;
   private _uiConfId?: number;
   public _dataLoader!: DataLoaderManager;
   private _playerVersion: string;
   public _logger: any;
   public _referrer?: string;
-  protected _isAnonymous: boolean;
+  protected _isAnonymous: boolean | undefined;
 
   public _networkRetryConfig: ProviderNetworkRetryParameters = {
     async: true,
@@ -56,7 +56,7 @@ export default class BaseProvider<MI> {
     return this._playerVersion;
   }
 
-  public get isAnonymous(): boolean {
+  public get isAnonymous(): boolean | undefined {
     return this._isAnonymous;
   }
 

--- a/src/k-provider/ovp/config.ts
+++ b/src/k-provider/ovp/config.ts
@@ -26,6 +26,10 @@ export default class OVPConfiguration {
   public static get(): any {
     return clone(defaultConfig);
   }
+
+  public static get serviceUrl(): string {
+    return defaultConfig.serviceUrl;
+  }
 }
 
 export {OVPConfiguration};

--- a/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
+++ b/src/k-provider/ovp/response-types/kaltura-user-get-response.ts
@@ -1,0 +1,12 @@
+export class KalturaUserGetResponse {
+  public id: string;
+  private static readonly INVALID_IDS = ['0', '', null, undefined];
+
+  constructor(response: any) {
+    this.id = response.id;
+  }
+
+  public isAnonymous(): boolean {
+    return KalturaUserGetResponse.INVALID_IDS.includes(this.id);
+  }
+}

--- a/src/k-provider/ovp/services/user-service.ts
+++ b/src/k-provider/ovp/services/user-service.ts
@@ -1,0 +1,27 @@
+import OVPService from './ovp-service';
+import RequestBuilder from '../../../util/request-builder';
+
+const SERVICE_NAME: string = 'user';
+
+export default class OVPUserService extends OVPService {
+  /**
+   * Creates an instance of RequestBuilder for user.get
+   * @function getPlaybackContext
+   * @param {string} serviceUrl The service base URL
+   * @param {string} ks The ks
+   * @returns {RequestBuilder} The request builder
+   * @static
+   */
+  public static get(serviceUrl: string, ks: string): RequestBuilder {
+    const headers: Map<string, string> = new Map();
+    headers.set('Content-Type', 'application/json');
+    const request = new RequestBuilder(headers);
+    request.service = SERVICE_NAME;
+    request.action = 'get';
+    request.method = 'POST';
+    request.url = request.getUrl(serviceUrl);
+    request.tag = 'user-get';
+    request.params = { ks: ks, format: 1 };
+    return request;
+  }
+}

--- a/test/src/k-provider/ovp/provider.spec.js
+++ b/test/src/k-provider/ovp/provider.spec.js
@@ -11,6 +11,8 @@ import {toPlainObject} from '../../../../src/util/object';
 import OVPUserService from '../../../../src/k-provider/ovp/services/user-service';
 import {KalturaUserGetResponse} from '../../../../src/k-provider/ovp/response-types/kaltura-user-get-response';
 
+const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+
 describe('default configuration', () => {
   const partnerId = 1082342;
   const playerVersion = '1.2.3';
@@ -273,28 +275,39 @@ describe('OVPProvider.partnerId:1068292', function () {
     MultiRequestBuilder.prototype.execute.restore();
   });
 
-  it('should return config without plugins with drm data', async () => {
+  it('should return config without plugins with drm data', done => {
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.AnonymousMocEntryWithoutUIConfWithDrmData.response)});
       });
     });
 
-    const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+    // mock user get response
     sandbox.stub(OVPUserService, 'get').returns({
       doHttpRequest: () => Promise.resolve(mockUserResponse)
     });
-    await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-    expect(provider._isAnonymous).to.be.false;
 
-    try {
-      const mediaConfig = await provider.getMediaConfig({entryId: '1_rwbj3j0a'});
-      const data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.NoPluginsWithDrm));
-      data.session.isAnonymous = false;
-      mediaConfig.should.deep.equal(data);
-    } catch (err) {
-      throw err;
-    }
+    // initialize user response
+    provider.initializeUserResponse(provider.env.serviceUrl, ks)
+      .then(() => {
+        // fetch media configuration after user initialization
+        return provider.getMediaConfig({ entryId: '1_rwbj3j0a', ks: ks });
+      })
+      .then(
+        mediaConfig => {
+          try {
+            let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.NoPluginsWithDrm));
+            data.session.isAnonymous = false;
+            mediaConfig.should.deep.equal(data);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+        err => {
+          done(err);
+        }
+      );
   });
 
   it('should return reject when try to get config with wrong entryId', done => {
@@ -321,7 +334,7 @@ describe('OVPProvider.partnerId:1068292', function () {
     );
   });
 
-  it('should return config with plugins and with drm data', async () => {
+  it('should return config with plugins and with drm data', done => {
     provider = new OVPProvider({partnerId: partnerId, ks: ks, uiConfId: 38601981}, playerVersion);
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
@@ -332,21 +345,32 @@ describe('OVPProvider.partnerId:1068292', function () {
       });
     });
 
-    const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+    // mock user get response
     sandbox.stub(OVPUserService, 'get').returns({
       doHttpRequest: () => Promise.resolve(mockUserResponse)
     });
-    await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-    expect(provider._isAnonymous).to.be.false;
 
-    try {
-      const mediaConfig = await provider.getMediaConfig({entryId: '1_rwbj3j0a'});
-      const data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.WithPluginsWithDrm));
-      data.session.isAnonymous = false;
-      mediaConfig.should.deep.equal(data);
-    } catch (err) {
-      throw err;
-    }
+    // initialize user response
+    provider.initializeUserResponse(provider.env.serviceUrl, ks)
+      .then(() => {
+        // fetch media configuration after user initialization
+        return provider.getMediaConfig({ entryId: '1_rwbj3j0a', ks: ks });
+      })
+      .then(
+        mediaConfig => {
+          try {
+            let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.WithPluginsWithDrm));
+            data.session.isAnonymous = false;
+            mediaConfig.should.deep.equal(data);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+        err => {
+          done(err);
+        }
+      );
   });
 
   it('should return reject when try to get config with wrong uiConf ID', done => {
@@ -392,27 +416,38 @@ describe('OVPProvider.partnerId:0', function () {
     MultiRequestBuilder.prototype.execute.restore();
   });
 
-  it('should return entry', async () => {
+  it('should return entry', done => {
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
         resolve({response: new MultiRequestResult(BE_DATA.Partner0EntryData.response)});
       });
     });
 
-    const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+    // mock user get response
     sandbox.stub(OVPUserService, 'get').returns({
       doHttpRequest: () => Promise.resolve(mockUserResponse)
     });
-    await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-    expect(provider._isAnonymous).to.be.false;
 
-    try {
-      const mediaConfig = await provider.getMediaConfig({entryId: '0_pi55vv3r'});
-      const data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.EntryOfPartner0));
-      mediaConfig.should.deep.equal(data);
-    } catch (err) {
-      throw err;
-    }
+    // initialize user response
+    provider.initializeUserResponse(provider.env.serviceUrl, ks)
+      .then(() => {
+        // fetch media configuration after user initialization
+        return provider.getMediaConfig({ entryId: '0_pi55vv3r', ks: ks });
+      })
+      .then(
+        mediaConfig => {
+          try {
+            let data = JSON.parse(JSON.stringify(MEDIA_CONFIG_DATA.EntryOfPartner0));
+            mediaConfig.should.deep.equal(data);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+        err => {
+          done(err);
+        }
+      );
   });
 });
 
@@ -639,7 +674,7 @@ describe('getMediaConfig', function () {
       );
     });
 
-    it('should set the bumper plugin with ks', async () => {
+    it('should set the bumper plugin with ks', done => {
       sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
         return new Promise(resolve => {
           resolve({response: new MultiRequestResult(BE_DATA.EntryWithBumperWithKs.response)});
@@ -647,23 +682,34 @@ describe('getMediaConfig', function () {
       });
       provider = new OVPProvider({partnerId: partnerId}, playerVersion);
 
-      const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+      // mock user get response
       sandbox.stub(OVPUserService, 'get').returns({
         doHttpRequest: () => Promise.resolve(mockUserResponse)
       });
-      await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-      expect(provider._isAnonymous).to.be.false;
 
-      try {
-        const mediaConfig = await provider.getMediaConfig({entryId: '0_wifqaipd', ks});
-        mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
-        mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithBumperWithKs);
-      } catch (err) {
-        throw err;
-      }
+      // initialize user response
+      provider.initializeUserResponse(provider.env.serviceUrl, ks)
+        .then(() => {
+          // fetch media configuration after user initialization
+          return provider.getMediaConfig({ entryId: '0_wifqaipd', ks: ks });
+        })
+        .then(
+          mediaConfig => {
+            try {
+              mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
+              mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithBumperWithKs);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+          err => {
+            done(err);
+          }
+        );
     });
 
-    it('should not set the bumper plugin when no sources given', async () => {
+    it('should not set the bumper plugin when no sources given', done => {
       sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
         return new Promise(resolve => {
           resolve({response: new MultiRequestResult(BE_DATA.EntryWithBumperWitNoSources.response)});
@@ -671,20 +717,31 @@ describe('getMediaConfig', function () {
       });
       provider = new OVPProvider({partnerId: partnerId}, playerVersion);
 
-      const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+      // mock user get response
       sandbox.stub(OVPUserService, 'get').returns({
         doHttpRequest: () => Promise.resolve(mockUserResponse)
       });
-      await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-      expect(provider._isAnonymous).to.be.false;
 
-      try {
-        const mediaConfig = await provider.getMediaConfig({entryId: '0_wifqaipd', ks})
-        mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
-        mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithNoBumper);
-      } catch (err) {
-        throw err;
-      }
+      // initialize user response
+      provider.initializeUserResponse(provider.env.serviceUrl, ks)
+        .then(() => {
+          // fetch media configuration after user initialization
+          return provider.getMediaConfig({ entryId: '0_wifqaipd', ks: ks });
+        })
+        .then(
+          mediaConfig => {
+            try {
+              mediaConfig.sources.metadata.audioFlavors = toPlainObject(mediaConfig.sources.metadata.audioFlavors);
+              mediaConfig.should.deep.equal(MEDIA_CONFIG_DATA.EntryWithNoBumper);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          },
+          err => {
+            done(err);
+          }
+        );
     });
   });
 });
@@ -857,6 +914,10 @@ describe('getPlaybackContext', () => {
   const ks =
     'NTAwZjViZWZjY2NjNTRkNGEyMjU1MTg4OGE1NmUwNDljZWJkMzk1MXwxMDY4MjkyOzEwNjgyOTI7MTQ5MDE3NjE0NjswOzE0OTAwODk3NDYuMDIyNjswO3ZpZXc6Kix3aWRnZXQ6MTs7';
   const playerVersion = '1.2.3';
+  const getKsParam = (url) => {
+    if (url.indexOf('?') === -1) return 'ks/';
+    return url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
+  };
 
   afterEach(() => {
     sandbox.restore();
@@ -885,7 +946,7 @@ describe('getPlaybackContext', () => {
       });
   });
 
-  it('should add KS to direct playbackContext', async () => {
+  it('should add KS to direct playbackContext', done => {
     sandbox = sinon.createSandbox();
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
@@ -894,26 +955,38 @@ describe('getPlaybackContext', () => {
     });
     provider = new OVPProvider({partnerId: partnerId}, playerVersion);
 
-    const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+    // mock user get response
     sandbox.stub(OVPUserService, 'get').returns({
       doHttpRequest: () => Promise.resolve(mockUserResponse)
     });
-    await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-    expect(provider._isAnonymous).to.be.false;
 
-    try {
-      const mediaConfig = await provider.getMediaConfig({ entryId: '0_wifqaipd', ks: ks });
-      const result = mediaConfig.sources.dash.filter(source => {
-        const ksParam = source.url.indexOf('?') === -1 ? 'ks/' : source.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
-        return source.url.indexOf(ksParam + ks) !== -1;
-      });
-      result.should.deep.equal(mediaConfig.sources.dash);
-    } catch (err) {
-      throw err;
-    }
+    // initialize user response
+    provider.initializeUserResponse(provider.env.serviceUrl, ks)
+      .then(() => {
+        // fetch media configuration after user initialization
+        return provider.getMediaConfig({ entryId: '0_wifqaipd', ks: ks });
+      })
+      .then(
+        mediaConfig => {
+          try {
+            // validate that KS is correctly added to the DASH sources
+            const result = mediaConfig.sources.dash.filter(source => {
+              const ksParam = getKsParam(source.url);
+              return source.url.includes(ksParam + ks);
+            });
+            result.should.deep.equal(mediaConfig.sources.dash);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+        err => {
+          done(err);
+        }
+      );
   });
 
-  it('should add KS to external captions url', async () => {
+  it('should add KS to external captions url', done => {
     sandbox = sinon.createSandbox();
     sinon.stub(MultiRequestBuilder.prototype, 'execute').callsFake(function () {
       return new Promise(resolve => {
@@ -922,23 +995,35 @@ describe('getPlaybackContext', () => {
     });
     provider = new OVPProvider({partnerId: partnerId}, playerVersion);
 
-    const mockUserResponse = { id: 'roee.dean@kaltura.com' };
+    // mock user get response
     sandbox.stub(OVPUserService, 'get').returns({
       doHttpRequest: () => Promise.resolve(mockUserResponse)
     });
-    await provider.initializeUserResponse(provider.env.serviceUrl, ks);
-    expect(provider._isAnonymous).to.be.false;
 
-    try {
-      const mediaConfig = await provider.getMediaConfig({entryId: '1_rwbj3j0a', ks: ks})
-      const result = mediaConfig.sources.captions.filter(caption => {
-        const ksParam = caption.url.indexOf('?') === -1 ? 'ks/' : caption.url.indexOf('?ks') === -1 ? '&ks=' : '?ks=';
-        return caption.url.indexOf(ksParam + ks) !== -1;
-      });
-      result.should.deep.equal(mediaConfig.sources.captions);
-    } catch (err) {
-      throw err;
-    }
+    // initialize user response
+    provider.initializeUserResponse(provider.env.serviceUrl, ks)
+      .then(() => {
+        // fetch media configuration after user initialization
+        return provider.getMediaConfig({ entryId: '1_rwbj3j0a', ks: ks });
+      })
+      .then(
+        mediaConfig => {
+          try {
+            // validate that KS is correctly added to the Captions sources
+            const result = mediaConfig.sources.captions.filter(caption => {
+              const ksParam = getKsParam(caption.url);
+              return caption.url.includes(ksParam + ks);
+            });
+            result.should.deep.equal(mediaConfig.sources.captions);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        },
+        err => {
+          done(err);
+        }
+      );
   });
 
   it('should request entryId token {2:result:objects:0:id} in request with anonymous KS', done => {


### PR DESCRIPTION
### Description of the Changes

- Added a new service for Kaltura User Get using it inside the OVPProvider
- Concentrated the dealing with the flag config.session._isAnonymous in a single place in the file, instead of several places.
- Fixed the flag config.session._isAnonymous logic:
until now, config.session._isAnonymous was set to 'false' for every session that has ks (even if it's anonymous ks).
The fix insure that the flag config.session._isAnonymous will be set to 'false' only for sessions that have ks containing a valid user inside, otherwise the flag will be set to 'true'.

Related PR: https://github.com/kaltura/kaltura-player-js/pull/916

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)

[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ