### PR TITLE
fix(FEC-14248): Anonymous session based on if ks contain user - fix

### DIFF
--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -188,11 +188,11 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
               messages: OVPProviderParser.getErrorMessages(response)
             });
           }
-          const mediaEntry = OVPProviderParser.getMediaEntry(this.isAnonymous ? '' : this.ks, this.partnerId, this.uiConfId, response);
+          const mediaEntry = OVPProviderParser.getMediaEntry(this.ks, this.partnerId, this.uiConfId, response);
           Object.assign(mediaConfig.sources, this._getSourcesObject(mediaEntry));
           this._verifyMediaStatus(mediaEntry);
           this._verifyHasSources(mediaConfig.sources);
-          const bumper = OVPProviderParser.getBumper(response, this.isAnonymous ? '' : this.ks, this.partnerId);
+          const bumper = OVPProviderParser.getBumper(response, this.ks, this.partnerId);
           if (bumper) {
             Object.assign(mediaConfig.plugins, {bumper});
           }


### PR DESCRIPTION
### Description of the Changes

- Fix for always adding ks as a parameter for 'OVPProviderParser.getMediaEntry' and 'OVPProviderParser.getBumper'.

Related PR: 
[259](https://github.com/kaltura/playkit-js-providers/pull/259)
[916](https://github.com/kaltura/kaltura-player-js/pull/916)

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)

[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ