### PR TITLE
feat(FEC-14439): Add link to original entry when playing a clip entry

### DIFF
--- a/src/entities/media-entry.ts
+++ b/src/entities/media-entry.ts
@@ -81,6 +81,18 @@ export default class MediaEntry {
   public rawThumbnailUrl?: string;
 
   /**
+   * @member - The root entry ID
+   * @type {string}
+   */
+  public rootEntryId?: string;
+
+  /**
+   * @member - The capabilities of the entry
+   * @type {Array<string>}
+   */
+  public capabilities?: Array<string>;
+
+  /**
    * @constructor
    */
   constructor() {
@@ -106,7 +118,9 @@ export default class MediaEntry {
       poster: this.poster,
       assetReferenceType: this.assetReferenceType,
       downloadUrl: this.downloadUrl,
-      rawThumbnailUrl: this.rawThumbnailUrl
+      rawThumbnailUrl: this.rawThumbnailUrl,
+      rootEntryId: this.rootEntryId,
+      capabilities: this.capabilities
     };
   }
 }

--- a/src/k-provider/ovp/provider-parser.ts
+++ b/src/k-provider/ovp/provider-parser.ts
@@ -170,7 +170,7 @@ class OVPProviderParser {
     mediaEntry.metadata.tags = entry.tags || '';
     mediaEntry.status = entry.status;
     mediaEntry.rootEntryId = entry.rootEntryId;
-    mediaEntry.capabilities = entry.capabilities !== '' ? entry.capabilities.split(',') : [];
+    mediaEntry.capabilities = entry.capabilities ? entry.capabilities.split(',') : [];
 
     mediaEntry.type = OVPProviderParser._getEntryType(entry.entryType, entry.type);
     if (mediaEntry.type === MediaEntry.Type.LIVE) {

--- a/src/k-provider/ovp/provider-parser.ts
+++ b/src/k-provider/ovp/provider-parser.ts
@@ -169,6 +169,8 @@ class OVPProviderParser {
     if (entry.plays) mediaEntry.metadata.plays = entry.plays;
     mediaEntry.metadata.tags = entry.tags || '';
     mediaEntry.status = entry.status;
+    mediaEntry.rootEntryId = entry.rootEntryId;
+    mediaEntry.capabilities = entry.capabilities !== '' ? entry.capabilities.split(',') : [];
 
     mediaEntry.type = OVPProviderParser._getEntryType(entry.entryType, entry.type);
     if (mediaEntry.type === MediaEntry.Type.LIVE) {

--- a/src/k-provider/ovp/provider.ts
+++ b/src/k-provider/ovp/provider.ts
@@ -366,6 +366,8 @@ export default class OVPProvider extends BaseProvider<OVPProviderMediaInfoObject
     sourcesObject.poster = mediaEntry.poster;
     sourcesObject.rawThumbnailUrl = mediaEntry.rawThumbnailUrl;
     sourcesObject.downloadUrl = mediaEntry.downloadUrl;
+    sourcesObject.rootEntryId = mediaEntry.rootEntryId;
+    sourcesObject.capabilities = mediaEntry.capabilities;
     if (mediaEntry.sources.captions) {
       sourcesObject.captions = mediaEntry.sources.captions;
     }

--- a/src/k-provider/ovp/request-params/base-entry-response-profile.ts
+++ b/src/k-provider/ovp/request-params/base-entry-response-profile.ts
@@ -1,5 +1,5 @@
 const FIELDS =
-  'id,referenceId,name,description,thumbnailUrl,dataUrl,duration,msDuration,flavorParamsIds,mediaType,type,tags,dvrStatus,externalSourceType,status,createdAt,updatedAt,endDate,plays,views,downloadUrl,creatorId';
+  'id,referenceId,name,description,thumbnailUrl,dataUrl,duration,msDuration,flavorParamsIds,mediaType,type,tags,dvrStatus,externalSourceType,status,createdAt,updatedAt,endDate,plays,views,downloadUrl,creatorId,rootEntryId,capabilities';
 const RESPONSE_PROFILE_TYPE = {
   INCLUDE_FIELDS: 1,
   EXCLUDE_FIELDS: 2

--- a/src/k-provider/ovp/response-types/kaltura-media-entry.ts
+++ b/src/k-provider/ovp/response-types/kaltura-media-entry.ts
@@ -166,6 +166,18 @@ export class KalturaMediaEntry {
   public rawThumbnailUrl: string;
 
   /**
+   * @member - The root entry ID
+   * @type {string}
+   */
+  public rootEntryId: string;
+
+  /**
+   * @member - The capabilities of the entry
+   * @type {string}
+   */
+  public capabilities: string;
+
+  /**
    * @constructor
    * @param {Object} entry The json response
    */
@@ -192,5 +204,7 @@ export class KalturaMediaEntry {
     this.plays = entry.plays;
     this.views = entry.views;
     this.downloadUrl = entry.downloadUrl;
+    this.rootEntryId = entry.rootEntryId;
+    this.capabilities = entry.capabilities;
   }
 }

--- a/src/types/media-config-sources.ts
+++ b/src/types/media-config-sources.ts
@@ -22,4 +22,6 @@ export type ProviderMediaConfigSourcesObject = {
   rawThumbnailUrl?: string;
   seekFrom?: number;
   clipTo?: number;
+  rootEntryId?: string;
+  capabilities?: Array<string>;
 };

--- a/src/types/media-entry.ts
+++ b/src/types/media-entry.ts
@@ -14,4 +14,6 @@ export type ProviderMediaEntryObject = {
   downloadUrl?: string;
   assetReferenceType?: string;
   rawThumbnailUrl?: string;
+  rootEntryId?: string;
+  capabilities?: Array<string>;
 };

--- a/test/src/k-provider/ovp/be-data.js
+++ b/test/src/k-provider/ovp/be-data.js
@@ -24,6 +24,8 @@ const AnonymousMocEntryWithoutUIConfNoDrmData = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -341,6 +343,8 @@ const BlockActionEntry = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -438,6 +442,8 @@ const AnonymousMocEntryWithoutUIConfWithDrmData = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -701,6 +707,8 @@ const EntryWithUIConfNoDrmData = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1034,6 +1042,8 @@ const EntryWithUIConfWithDrmData = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1287,6 +1297,8 @@ const WrongUiConfID = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1524,6 +1536,8 @@ const AudioEntryWithoutPlugins = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1664,6 +1678,8 @@ const ImageEntryWithoutPlugins = {
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1706,6 +1722,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_fu4ifhie/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1719,6 +1737,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_15xrxwvo/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1732,6 +1752,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_p8aigvgu/version/100022',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1746,6 +1768,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_ttfy4uu0/version/100032',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1760,6 +1784,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_df8g87v8/version/100032',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1774,6 +1800,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_hut6q26s/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1788,6 +1816,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_x8n0mub7/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1801,6 +1831,8 @@ const PlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_4ktof5po/version/100000',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       }
     ],
@@ -1844,6 +1876,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_fu4ifhie/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1857,6 +1891,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_15xrxwvo/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1870,6 +1906,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_p8aigvgu/version/100022',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1884,6 +1922,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_ttfy4uu0/version/100032',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1898,6 +1938,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_df8g87v8/version/100032',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1912,6 +1954,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_hut6q26s/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1926,6 +1970,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_x8n0mub7/version/100002',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       },
       {
@@ -1939,6 +1985,8 @@ const AnonymousPlaylistById = {
         type: 1,
         thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_4ktof5po/version/100000',
         downloadUrl: '',
+        rootEntryId: '',
+        capabilities: '',
         objectType: 'KalturaMediaEntry'
       }
     ],
@@ -1985,6 +2033,8 @@ const PlaylistByEntryList = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -2003,6 +2053,8 @@ const PlaylistByEntryList = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_p8aigvgu/version/100022',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -2052,6 +2104,8 @@ const AnonymousPlaylistByEntryList = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -2071,6 +2125,8 @@ const AnonymousPlaylistByEntryList = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_p8aigvgu/version/100022',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -2102,6 +2158,8 @@ const EntryInImport = {
             type: 1,
             thumbnailUrl: 'http://cfvod.kaltura.com/p/2506752/sp/250675200/thumbnail/entry_id/0_fknc1xml/version/0',
             downloadUrl: '',
+            rootEntryId: '',
+            capabilities: '',
             objectType: 'KalturaMediaEntry'
           }
         ],
@@ -2147,6 +2205,8 @@ const EntryInPreConvert = {
             type: 1,
             thumbnailUrl: 'http://cfvod.kaltura.com/p/2506752/sp/250675200/thumbnail/entry_id/0_fknc1xml/version/0',
             downloadUrl: '',
+            rootEntryId: '',
+            capabilities: '',
             objectType: 'KalturaMediaEntry'
           }
         ],
@@ -2193,6 +2253,8 @@ const EntryInReady = {
             type: 1,
             thumbnailUrl: 'http://cfvod.kaltura.com/p/2506752/sp/250675200/thumbnail/entry_id/0_yp010l8a/version/100022',
             downloadUrl: '',
+            rootEntryId: '',
+            capabilities: '',
             objectType: 'KalturaMediaEntry'
           }
         ],
@@ -2500,6 +2562,8 @@ const EntryWithBumper = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -2899,6 +2963,8 @@ const EntryWithBumperWithKs = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -3298,6 +3364,8 @@ const EntryDirectWithKs = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -3374,6 +3442,8 @@ const EntryWithBumperWitNoSources = {
           type: 1,
           thumbnailUrl: 'http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -3725,6 +3795,8 @@ const Partner0EntryData = {
           type: 1,
           thumbnailUrl: 'https://cfvod.kaltura.com/p/1645161/sp/164516100/thumbnail/entry_id/0_pi55vv3r/version/100002',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],

--- a/test/src/k-provider/ovp/media-config-data.js
+++ b/test/src/k-provider/ovp/media-config-data.js
@@ -188,7 +188,9 @@ const NoPluginsNoDrm = {
     ],
     image: [],
     document: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -343,7 +345,9 @@ const RegexAppliedPlayManifestSources = {
       ChannelName: 'Disney Channel SE',
       aspectRatio: 1.78
     },
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   },
   plugins: {}
 };
@@ -501,7 +505,9 @@ const RegexAppliedAllSources = {
           'https://qa-kes-ebu-01.dev.kaltura.com/kAPI/cfvod.kaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/1_6jfbcdz9/segmentIndex/-1/version/11/captions.vtt'
       }
     ],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -568,7 +574,9 @@ const NoPluginsWithDrm = {
     ],
     image: [],
     document: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -715,7 +723,9 @@ const WithPluginsNoDrm = {
     ],
     image: [],
     document: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -783,7 +793,9 @@ const WithPluginsWithDrm = {
     ],
     image: [],
     document: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -848,7 +860,9 @@ const AudioEntryWithoutPlugins = {
     ],
     image: [],
     document: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -877,7 +891,9 @@ const ImageEntryWithoutPlugins = {
     dash: [],
     hls: [],
     progressive: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   }
 };
 
@@ -944,6 +960,8 @@ const WrongUiConfID = [
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vel semper libero. Curabitur in felis elementum, porttitor sem ac, volutpat mi. Sed dignissim facilisis magna, ac suscipit orci suscipit id. Suspendisse feugiat sapien laoreet auctor convallis. Cras volutpat dictum massa, in pharetra erat placerat eget. Donec at elit est. Donec id cursus elit. Etiam sit amet sapien sed mi aliquam finibus at lobortis diam. Aenean at gravida libero.',
           thumbnailUrl: 'http://kaltura.com/p/1082342/sp/108234200/thumbnail/entry_id/1_rsrdfext/version/100002/width/640/height/360',
           downloadUrl: '',
+          rootEntryId: '',
+          capabilities: '',
           objectType: 'KalturaMediaEntry'
         }
       ],
@@ -1265,7 +1283,9 @@ const EntryWithBumper = {
         url: 'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2'
       }
     ],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   },
   plugins: {
     bumper: {
@@ -1387,7 +1407,9 @@ const EntryWithBumperWithKs = {
           'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionasset/action/serveWebVTT/captionAssetId/0_njhnv6na/segmentIndex/-1/version/2/captions.vtt?testParam=abc&ks=YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       }
     ],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   },
   plugins: {
     bumper: {
@@ -1510,7 +1532,9 @@ const EntryWithNoBumper = {
           'http://cdntesting.qa.mkaltura.com/api_v3/index.php/service/caption_captionAsset/action/serve/captionAssetId/0_njhnv6na/v/2/ks/YmMzNzUyZWM4ZmVkYjRiMzRlOTBlYTZjMGY2YTI1NzRkZDUwZjZjNnwxMDkxOzEwOTE7MTYwNTcyMjI5NDsyOzE2MDU2MzU4OTQuMTA0MzthdmkuYmFydWNoQGthbHR1cmEuY29tOyosZGlzYWJsZWVudGl0bGVtZW50Ozs'
       }
     ],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   },
   plugins: {}
 };
@@ -1587,7 +1611,9 @@ const EntryOfPartner0 = {
       aspectRatio: 1.33
     },
     captions: [],
-    downloadUrl: ''
+    downloadUrl: '',
+    rootEntryId: '',
+    capabilities: []
   },
   plugins: {}
 };

--- a/test/src/k-provider/ovp/provider-parser-data.js
+++ b/test/src/k-provider/ovp/provider-parser-data.js
@@ -16,7 +16,9 @@ const youtubeMediaEntryData = [
       duration: 0,
       poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001',
       tags: '',
-      downloadUrl: ''
+      downloadUrl: '',
+      rootEntryId: '',
+      capabilities: ''
     },
     playBackContextResult: {
       hasError: false,
@@ -83,7 +85,9 @@ const youtubeMediaEntryResult = {
   },
   type: 'Unknown',
   poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001',
-  downloadUrl: ''
+  downloadUrl: '',
+  rootEntryId: '',
+  capabilities: []
 };
 
 const liveMediaEntryData = [
@@ -103,7 +107,9 @@ const liveMediaEntryData = [
       duration: 0,
       poster: 'https://cfvod.kaltura.com/p/1111/sp/1111/thumbnail/entry_id/1234/version/100001',
       tags: '',
-      downloadUrl: ''
+      downloadUrl: '',
+      rootEntryId: '',
+      capabilities: ''
     },
     playBackContextResult: {
       hasError: false,


### PR DESCRIPTION
### Description of the Changes

- add `rootEntryId` and `capabilities` to the response profile of `baseEntry` service.
- fix tests

**related PRs:**
https://github.com/kaltura/playkit-js-reels/pull/23
https://github.com/kaltura/playkit-js-clip-to-parent/pull/1

#### Resolves FEC-14439
