### PR TITLE
feat(SUP-52024): Player Multirequest call - addition of ClientTag parameter in request body

### DIFF
--- a/src/k-provider/common/base-provider.ts
+++ b/src/k-provider/common/base-provider.ts
@@ -21,6 +21,7 @@ export default class BaseProvider<MI> {
   public _logger: any;
   public _referrer?: string;
   protected _isAnonymous: boolean | undefined;
+  protected _clientTag: string | undefined;
 
   public _networkRetryConfig: ProviderNetworkRetryParameters = {
     async: true,
@@ -60,6 +61,10 @@ export default class BaseProvider<MI> {
     return this._isAnonymous;
   }
 
+  public get clientTag(): string | undefined {
+    return this._clientTag;
+  }
+
   constructor(options: ProviderOptionsObject, playerVersion: string) {
     setLogger(options.logger);
     this._partnerId = options.partnerId;
@@ -69,6 +74,7 @@ export default class BaseProvider<MI> {
     this._ks = options.ks || '';
     this._playerVersion = playerVersion;
     this._referrer = options.referrer;
+    this._clientTag = options.clientTag;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/k-provider/ott/loaders/data-loader-manager.ts
+++ b/src/k-provider/ott/loaders/data-loader-manager.ts
@@ -8,8 +8,8 @@ import {ProviderNetworkRetryParameters} from '../../../types';
  * @param {ProviderNetworkRetryParameters} [networkRetryConfig] - network retry configuration
  */
 export default class OTTDataLoaderManager extends DataLoaderManager {
-  constructor(partnerId: number, ks: string = '', networkRetryConfig: ProviderNetworkRetryParameters) {
+  constructor(partnerId: number, ks: string = '', networkRetryConfig: ProviderNetworkRetryParameters, clientTag: string|undefined) {
     super(networkRetryConfig);
-    this._multiRequest = OTTService.getMultiRequest(ks, partnerId);
+    this._multiRequest = OTTService.getMultiRequest(ks, partnerId, clientTag);
   }
 }

--- a/src/k-provider/ott/provider.ts
+++ b/src/k-provider/ott/provider.ts
@@ -48,7 +48,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
       this.ks = mediaInfo.ks;
       this._isAnonymous = false;
     }
-    this._dataLoader = new OTTDataLoaderManager(this.partnerId, this.ks, this._networkRetryConfig);
+    this._dataLoader = new OTTDataLoaderManager(this.partnerId, this.ks, this._networkRetryConfig, this.clientTag);
     return new Promise((resolve, reject) => {
       const entryId = mediaInfo.entryId;
       if (entryId) {
@@ -160,7 +160,7 @@ export default class OTTProvider extends BaseProvider<OTTProviderMediaInfoObject
       this.ks = entryListInfo.ks;
       this._isAnonymous = false;
     }
-    this._dataLoader = new OTTDataLoaderManager(this.partnerId, this.ks, this._networkRetryConfig);
+    this._dataLoader = new OTTDataLoaderManager(this.partnerId, this.ks, this._networkRetryConfig, this.clientTag);
     return new Promise((resolve, reject) => {
       const entries = entryListInfo.entries;
       if (entries && entries.length) {

--- a/src/k-provider/ott/services/ott-service.ts
+++ b/src/k-provider/ott/services/ott-service.ts
@@ -9,11 +9,11 @@ export default class OTTService {
    * @function getMultiRequest
    * @param {string} ks The ks
    * @param {string} partnerId The partner ID
-   * @param clientTag
+   * @param {string|undefined} clientTag the client tage
    * @returns {MultiRequestBuilder} The multi request builder
    * @static
    */
-  public static getMultiRequest(ks: string, partnerId?: number, clientTag?: string|undefined): MultiRequestBuilder {
+  public static getMultiRequest(ks: string, partnerId?: number, clientTag?: string | undefined): MultiRequestBuilder {
     const config = OTTConfiguration.get();
     const ottParams = config.serviceParams;
     if (ks) {

--- a/src/k-provider/ott/services/ott-service.ts
+++ b/src/k-provider/ott/services/ott-service.ts
@@ -9,7 +9,7 @@ export default class OTTService {
    * @function getMultiRequest
    * @param {string} ks The ks
    * @param {string} partnerId The partner ID
-   * @param {string|undefined} clientTag the client tage
+   * @param {string|undefined} clientTag the client tag
    * @returns {MultiRequestBuilder} The multi request builder
    * @static
    */

--- a/src/k-provider/ott/services/ott-service.ts
+++ b/src/k-provider/ott/services/ott-service.ts
@@ -9,10 +9,11 @@ export default class OTTService {
    * @function getMultiRequest
    * @param {string} ks The ks
    * @param {string} partnerId The partner ID
+   * @param clientTag
    * @returns {MultiRequestBuilder} The multi request builder
    * @static
    */
-  public static getMultiRequest(ks: string, partnerId?: number): MultiRequestBuilder {
+  public static getMultiRequest(ks: string, partnerId?: number, clientTag?: string|undefined): MultiRequestBuilder {
     const config = OTTConfiguration.get();
     const ottParams = config.serviceParams;
     if (ks) {
@@ -20,6 +21,9 @@ export default class OTTService {
     }
     if (partnerId) {
       Object.assign(ottParams, {partnerId: partnerId});
+    }
+    if (clientTag) {
+      Object.assign(ottParams, {clientTag: clientTag});
     }
     const headers: Map<string, string> = new Map();
     headers.set('Content-Type', 'application/json');

--- a/src/types/entry-list.ts
+++ b/src/types/entry-list.ts
@@ -3,4 +3,5 @@ import {ProviderMediaInfoObject} from './media-info';
 export type ProviderEntryListObject = {
   entries: Array<ProviderMediaInfoObject>;
   ks?: string;
+  clientTag?: string;
 };

--- a/src/types/media-info.ts
+++ b/src/types/media-info.ts
@@ -4,6 +4,7 @@ export type OVPProviderMediaInfoObject = {
   entryId?: string;
   referenceId?: string;
   ks?: string;
+  clientTag?: string;
 };
 
 export type OTTProviderMediaInfoObject = OVPProviderMediaInfoObject & {

--- a/src/types/provider-options.ts
+++ b/src/types/provider-options.ts
@@ -18,4 +18,5 @@ export type ProviderOptionsObject = {
   vrTag?: string;
   unisphereLoaderUrl?: string;
   useHeaderForKs?: boolean;
+  clientTag?: string;
 };


### PR DESCRIPTION
request:
add option to send clientTag for ott player in multirequests

solution:
change on provider config to be able to put clientTag, and change ottProvider to support it

solve [SUP-52024](https://kaltura.atlassian.net/browse/SUP-52024)


[SUP-52024]: https://kaltura.atlassian.net/browse/SUP-52024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ